### PR TITLE
Correct typos

### DIFF
--- a/newrelic_lambda_cli/integrations.py
+++ b/newrelic_lambda_cli/integrations.py
@@ -62,7 +62,7 @@ def create_role(session, role_policy, nr_account_id):
     template_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "templates",
-        "nr-integration-role.yaml",
+        "nr-lambda-integration-role.yaml",
     )
     with open(template_path) as template:
         client.create_stack(
@@ -71,7 +71,7 @@ def create_role(session, role_policy, nr_account_id):
             Parameters=[
                 {
                     "ParameterKey": "NewRelicAccountNumber",
-                    "ParameterValue": nr_account_id,
+                    "ParameterValue": str(nr_account_id),
                 },
                 {"ParameterKey": "PolicyName", "ParameterValue": role_policy_name},
             ],


### PR DESCRIPTION
The latest release seems to have couple of typos :( As I am unfamiliar with the codebase this might not be the best solution but this makes the `newrelic-lambda integrations install` command work again.