### PR TITLE
Add option to skip permissions checks

### DIFF
--- a/newrelic_lambda_cli/cli/decorators.py
+++ b/newrelic_lambda_cli/cli/decorators.py
@@ -21,6 +21,12 @@ AWS_OPTIONS = [
         metavar="<region>",
         type=click.Choice(utils.all_lambda_regions()),
     ),
+    click.option(
+        "--aws-permissions-check/--no-aws-permissions-check",
+        help="Perform AWS permissions checks",
+        default=True,
+        show_default=True,
+    ),
 ]
 
 NR_OPTIONS = [

--- a/newrelic_lambda_cli/cli/functions.py
+++ b/newrelic_lambda_cli/cli/functions.py
@@ -28,11 +28,12 @@ def register(group):
     help="Apply a filter to the list.",
     type=click.Choice(["all", "installed", "not-installed"]),
 )
-def list(aws_profile, aws_region, filter):
+def list(aws_profile, aws_region, aws_permissions_check, filter):
     """List AWS Lambda Functions"""
     _, rows = shutil.get_terminal_size((80, 50))
     session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
-    permissions.ensure_lambda_list_permissions(session)
+    if aws_permissions_check:
+        permissions.ensure_lambda_list_permissions(session)
     funcs = functions.list_functions(session, filter)
 
     def _format(funcs, header=False):

--- a/newrelic_lambda_cli/cli/integrations.py
+++ b/newrelic_lambda_cli/cli/integrations.py
@@ -36,6 +36,7 @@ def register(group):
 def install(
     aws_profile,
     aws_region,
+    aws_permissions_check,
     aws_role_policy,
     linked_account_name,
     nr_account_id,
@@ -44,7 +45,9 @@ def install(
 ):
     """Install New Relic AWS Lambda Integration"""
     session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
-    permissions.ensure_integration_install_permissions(session)
+
+    if aws_permissions_check:
+        permissions.ensure_integration_install_permissions(session)
 
     click.echo("Validating New Relic credentials")
     gql_client = gql.validate_gql_credentials(nr_account_id, nr_api_key, nr_region)
@@ -75,10 +78,12 @@ def install(
 
 @click.command(name="uninstall")
 @add_options(AWS_OPTIONS)
-def uninstall(aws_profile, aws_region):
+def uninstall(aws_profile, aws_region, aws_permissions_check):
     """Uninstall New Relic AWS Lambda Integration"""
     session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
-    permissions.ensure_integration_uninstall_permissions(session)
+
+    if aws_permissions_check:
+        permissions.ensure_integration_uninstall_permissions(session)
 
     click.confirm(
         "This will uninstall the New Relic AWS Lambda log ingestion. "

--- a/newrelic_lambda_cli/cli/layers.py
+++ b/newrelic_lambda_cli/cli/layers.py
@@ -53,10 +53,21 @@ def register(group):
     is_flag=True,
 )
 @click.pass_context
-def install(ctx, nr_account_id, aws_profile, aws_region, function, layer_arn, upgrade):
+def install(
+    ctx,
+    nr_account_id,
+    aws_profile,
+    aws_region,
+    aws_permissions_check,
+    function,
+    layer_arn,
+    upgrade,
+):
     """Install New Relic AWS Lambda Layer"""
     session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
-    permissions.ensure_lambda_install_permissions(session)
+
+    if aws_permissions_check:
+        permissions.ensure_lambda_install_permissions(session)
 
     res = layers.install(session, function, layer_arn, nr_account_id, upgrade)
     if not res:
@@ -79,10 +90,12 @@ def install(ctx, nr_account_id, aws_profile, aws_region, function, layer_arn, up
     help="Lambda function name or ARN",
 )
 @click.pass_context
-def uninstall(ctx, aws_profile, aws_region, function):
+def uninstall(ctx, aws_profile, aws_region, aws_permissions_check, function):
     """Uninstall New Relic AWS Lambda Layer"""
     session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
-    permissions.ensure_lambda_uninstall_permissions(session)
+
+    if aws_permissions_check:
+        permissions.ensure_lambda_uninstall_permissions(session)
 
     res = layers.uninstall(session, function)
     if not res:

--- a/newrelic_lambda_cli/cli/subscriptions.py
+++ b/newrelic_lambda_cli/cli/subscriptions.py
@@ -27,10 +27,12 @@ def register(group):
     metavar="<arn>",
     required=True,
 )
-def install(aws_profile, aws_region, function):
+def install(aws_profile, aws_region, aws_permissions_check, function):
     """Install New Relic AWS Lambda Log Subscription"""
     session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
-    permissions.ensure_subscription_install_permissions(session)
+
+    if aws_permissions_check:
+        permissions.ensure_subscription_install_permissions(session)
 
     subscriptions.create_log_subscription(session, function)
     done("Install Complete")

--- a/newrelic_lambda_cli/permissions.py
+++ b/newrelic_lambda_cli/permissions.py
@@ -41,13 +41,18 @@ def check_permissions(session, actions, resources=None, context=None):
     caller_arn = caller["Arn"]
 
     # docs: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html#IAM.Client.simulate_principal_policy
-    results = iam.simulate_principal_policy(
-        PolicySourceArn=caller_arn,
-        ActionNames=actions,
-        ResourceArns=resources,
-        ContextEntries=context_entries,
-    )["EvaluationResults"]
-
+    results = None
+    try:
+        results = iam.simulate_principal_policy(
+            PolicySourceArn=caller_arn,
+            ActionNames=actions,
+            ResourceArns=resources,
+            ContextEntries=context_entries,
+        )["EvaluationResults"]
+    except botocore.errorfactory.InvalidInputException:
+        raise click.UsageError(
+            "Error simulating IAM policies, try passing --no-aws-permissions-check to override."
+        )
     return sorted(
         [
             result["EvalActionName"]


### PR DESCRIPTION
AWS accounts can have permission to operate on resources without having access to SimulatePrincipalPolicy.

Currently, such accounts cannot use the CLI due to the permissions check.

This PR allows users to override those checks.

Signed-off-by: Erica Windisch <ewindisch@newrelic.com>