### PR TITLE
Revert "Pin graphql-core to <3.0.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,15 +20,7 @@ setup(
     author_email="serverless-dev@newrelic.com",
     url="https://github.com/newrelic/newrelic-lambda-cli",
     packages=find_packages(exclude=("tests", "tests.*")),
-    install_requires=[
-        "boto3",
-        "click",
-        "colorama",
-        "gql",
-        "graphql-core<3.0.0",
-        "requests",
-        "tabulate",
-    ],
+    install_requires=["boto3", "click", "colorama", "gql", "requests", "tabulate"],
     setup_requires=["pytest-runner"],
     tests_require=["coverage", "pytest", "pytest-click", "pytest-cov", "requests"],
     entry_points={


### PR DESCRIPTION
Upstream pinned `gql` to graphql-core<2.0 so I am suggesting we revert newrelic/newrelic-lambda-cli#29 which forced us to use graphql-core<3. Users are now reporting dependency conflicts attempting to install.

It looks like they forked their own library to `gql-next` which uses the newer graphql-core library and is only supported on 3.6+. The original gql library seems to support a wider range of language versions, but is less type-safe (this is the library we originally developed on)