### PR TITLE
import botocore in order to catch botocore errors

### DIFF
--- a/newrelic_lambda_cli/permissions.py
+++ b/newrelic_lambda_cli/permissions.py
@@ -1,4 +1,5 @@
 import click
+import botocore
 
 
 def check_permissions(session, actions, resources=None, context=None):


### PR DESCRIPTION
In order to catch errror in permissions.py we need to import botocore class.

Issue Related: https://github.com/newrelic/newrelic-lambda-cli/issues/50