### PR TITLE
Bump version of ingest function

### DIFF
--- a/newrelic_lambda_cli/templates/newrelic-log-ingestion.yaml
+++ b/newrelic_lambda_cli/templates/newrelic-log-ingestion.yaml
@@ -12,6 +12,6 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:463657938898:applications/NewRelic-log-ingestion
-        SemanticVersion: 2.0.1
+        SemanticVersion: 2.1.0
       Parameters:
         NRLicenseKey: !Ref NewRelicLicenseKey


### PR DESCRIPTION
We just published version 2.1.0 of the ingest lambda. We need to bump the version we refer to to reflect that.