### PR TITLE
Add support for a custom log subscription filter pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ newrelic-lambda layers install \
 | Option | Required? | Description |
 |--------|-----------|-------------|
 | `--function` or `-f` | Yes | The AWS Lambda function name or ARN in which to add a layer. Can provide multiple `--function` arguments. Will also accept `all`, `installed` and `not-installed` similar to `newrelic-lambda functions list`. |
-| `--exclude` or `-e` | No | A function name to exclude while installing layers. Can provide multiple `--exclude` arguments. Only checked when `all`, `installed` and `not-installed` are used. See `newrelic-lambda functions list` for function names. |
 | `--nr-account-id` or `-a` | Yes | The [New Relic Account ID](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id) this function should use. Can also use the `NEW_RELIC_ACCOUNT_ID` environment variable. |
+| `--exclude` or `-e` | No | A function name to exclude while installing layers. Can provide multiple `--exclude` arguments. Only checked when `all`, `installed` and `not-installed` are used. See `newrelic-lambda functions list` for function names. |
 | `--layer-arn` or `-l` | No | Specify a specific layer version ARN to use. This is auto detected by default. |
 | `--upgrade` or `-u` | No | Permit upgrade to the latest layer version for this region and runtime. |
 | `--aws-profile` or `-p` | No | The AWS profile to use for this command. Can also use `AWS_PROFILE`. Will also check `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables if not using AWS CLI. |
@@ -167,13 +167,14 @@ newrelic-lambda functions list --filter installed
 #### Install Log Subscription
 
 ```bash
-newrelic-lambda subscriptions install \--function <name or arn>
+newrelic-lambda subscriptions install --function <name or arn>
 ```
 
 | Option | Required? | Description |
 |--------|-----------|-------------|
 | `--function` or `-f` | Yes | The AWS Lambda function name or ARN in which to add a log subscription. Can provide multiple `--function` arguments. Will also accept `all`, `installed` and `not-installed` similar to `newrelic-lambda functions list`. |
 | `--exclude` or `-e` | No | A function name to exclude while installing subscriptions. Can provide multiple `--exclude` arguments. Only checked when `all`, `installed` and `not-installed` are used. See `newrelic-lambda functions list` for function names. |
+| `--filter-pattern` | No | Specify a custom log subscription filter pattern. To collect all logs use `--filter_pattern ""`. |
 | `--aws-profile` or `-p` | No | The AWS profile to use for this command. Can also use `AWS_PROFILE`. Will also check `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables if not using AWS CLI. |
 | `--aws-region` or `-r` | No | The AWS region this function is located. Can use `AWS_DEFAULT_REGION` environment variable. Defaults to AWS session region. |
 

--- a/newrelic_lambda_cli/cli/subscriptions.py
+++ b/newrelic_lambda_cli/cli/subscriptions.py
@@ -38,7 +38,16 @@ def register(group):
     metavar="<name>",
     multiple=True,
 )
-def install(aws_profile, aws_region, aws_permissions_check, functions, excludes):
+@click.option(
+    "filter_pattern",
+    "--filter-pattern",
+    default=subscriptions.DEFAULT_FILTER_PATTERN,
+    help="Custom log subscription filter pattern",
+    metavar="<pattern>",
+)
+def install(
+    aws_profile, aws_region, aws_permissions_check, functions, excludes, filter_pattern
+):
     """Install New Relic AWS Lambda Log Subscriptions"""
     session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
 
@@ -50,7 +59,9 @@ def install(aws_profile, aws_region, aws_permissions_check, functions, excludes)
     install_success = True
 
     for function in functions:
-        result = subscriptions.create_log_subscription(session, function)
+        result = subscriptions.create_log_subscription(
+            session, function, filter_pattern
+        )
         install_success = result and install_success
         if result:
             success("Successfully installed log subscription on %s" % function)


### PR DESCRIPTION
* Adds a `--filter-pattern` argument to `newrelic-lambda subscriptions install` to specify a custom log subscription filter pattern