### PR TITLE
Add an --enable-logs flag to enable New Relic Loggging mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ newrelic-lambda integrations install \
 | `--nr-account-id` or `-a` | Yes | The [New Relic Account ID](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id) for this integration. Can also use the `NEW_RELIC_ACCOUNT_ID` environment variable. |
 | `--nr-api-key` or `-k` | Yes | Your [New Relic User API Key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key). Can also use the `NEW_RELIC_API_KEY` environment variable. |
 | `--linked-account-name` or `-l` | Yes | A label for the New Relic Linked ACcount. This is how this integration will appear in New Relic. |
+| `--enable-logs` | No | Enables forwarding logs to New Relic Logging. This is disabled by default. Make sure you run `newrelic-lambda subscriptions install --function ... --filter-pattern ""` afterwards. |
 | `--nr-region` | No | The New Relic region to use for the integration. Can use the `NEW_RELIC_REGION` environment variable. Defaults to `us`. |
 | `--aws-profile` or `-p` | No | The AWS profile to use for this command. Can also use `AWS_PROFILE`. Will also check `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables if not using AWS CLI. |
 | `--aws-region` or `-r` | No | The AWS region for the integration. Can use `AWS_DEFAULT_REGION` environment variable. Defaults to AWS session region. |

--- a/newrelic_lambda_cli/integrations.py
+++ b/newrelic_lambda_cli/integrations.py
@@ -76,7 +76,7 @@ def create_role(session, role_policy, nr_account_id):
         click.echo("Done")
 
 
-def create_log_ingestion_function(session, nr_license_key):
+def create_log_ingestion_function(session, nr_license_key, enable_logs=False):
     client = session.client("cloudformation")
     stack_name = "NewRelicLogIngestion"
     template_path = os.path.join(
@@ -89,7 +89,14 @@ def create_log_ingestion_function(session, nr_license_key):
             StackName=stack_name,
             TemplateBody=template.read(),
             Parameters=[
-                {"ParameterKey": "NewRelicLicenseKey", "ParameterValue": nr_license_key}
+                {
+                    "ParameterKey": "NewRelicLicenseKey",
+                    "ParameterValue": nr_license_key,
+                },
+                {
+                    "ParameterKey": "NewRelicLoggingEnabled",
+                    "ParameterValue": "True" if enable_logs else "False",
+                },
             ],
             Capabilities=["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
         )
@@ -183,7 +190,7 @@ def validate_linked_account(session, gql, linked_account_name):
             )
 
 
-def install_log_ingestion(session, nr_license_key):
+def install_log_ingestion(session, nr_license_key, enable_logs=False):
     """
     Installs the New Relic AWS Lambda log ingestion function and role.
 
@@ -198,7 +205,7 @@ def install_log_ingestion(session, nr_license_key):
                 % session.region_name
             )
             try:
-                create_log_ingestion_function(session, nr_license_key)
+                create_log_ingestion_function(session, nr_license_key, enable_logs)
             except Exception as e:
                 failure("Failed to create 'newrelic-log-ingestion' function: %s" % e)
                 return False

--- a/newrelic_lambda_cli/templates/newrelic-log-ingestion.yaml
+++ b/newrelic_lambda_cli/templates/newrelic-log-ingestion.yaml
@@ -4,7 +4,11 @@ Parameters:
   NewRelicLicenseKey:
     Type: String
     Description: The New Relic account license key
-    Default: 'YOUR_LICENSE_KEY'
+    Default: "YOUR_LICENSE_KEY"
+  NewRelicLoggingEnabled:
+    Type: String
+    Description: Determines if logs are forwarded to New Relic Logging
+    Default: "False"
 
 Resources:
   NewRelicLogIngestion:
@@ -15,3 +19,4 @@ Resources:
         SemanticVersion: 2.1.2
       Parameters:
         NRLicenseKey: !Ref NewRelicLicenseKey
+        NRLoggingEnabled: !Ref NewRelicLoggingEnabled


### PR DESCRIPTION
* Adds a `--enable-logs` flag to the `newrelic-lambda integrations install` command to enable New Relic Logging mode in the log ingestion function