### PR TITLE
Fix BadParameter error call that was throwing exception

### DIFF
--- a/newrelic_lambda_cli/api.py
+++ b/newrelic_lambda_cli/api.py
@@ -307,7 +307,7 @@ def validate_gql_credentials(nr_account_id, nr_api_key, nr_region):
     try:
         return NewRelicGQL(nr_account_id, nr_api_key, nr_region)
     except requests.exceptions.HTTPError:
-        raise click.BadParameterError(
+        raise click.BadParameter(
             "Could not authenticate with New Relic. Check that your New Relic API Key "
             "is valid and try again.",
             param="nr_api_key",


### PR DESCRIPTION
When handling API key errors, this exception was getting thrown:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/usr/local/bin/newrelic-lambda", line 8, in <module>
sys.exit(main())
File "/usr/local/lib/python3.7/site-packages/newrelic_lambda_cli/utils.py", line 24, in _boto_error_wrapper
return func(*args, **kwargs)
File "/usr/local/lib/python3.7/site-packages/newrelic_lambda_cli/cli/__init__.py", line 25, in main
cli()
File "/usr/local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
return self.main(*args, **kwargs)
File "/usr/local/lib/python3.7/site-packages/click/core.py", line 717, in main
rv = self.invoke(ctx)
File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/usr/local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/usr/local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
return callback(*args, **kwargs)
File "/usr/local/lib/python3.7/site-packages/newrelic_lambda_cli/cli/integrations.py", line 57, in install
nr_license_key = api.retrieve_license_key(gql_client)
File "/usr/local/lib/python3.7/site-packages/newrelic_lambda_cli/api.py", line 321, in retrieve_license_key
raise click.BadParameterError(
AttributeError: module 'click' has no attribute 'BadParameterError'
```

The actual attribute should be "BadParameter": http://click.palletsprojects.com/en/5.x/api/#click.BadParameter