### PR TITLE
Set IAM PermissionsBoundary on created IAM Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ newrelic-lambda integrations install \
 | `--aws-profile` or `-p` | No | The AWS profile to use for this command. Can also use `AWS_PROFILE`. Will also check `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables if not using AWS CLI. |
 | `--aws-region` or `-r` | No | The AWS region for the integration. Can use `AWS_DEFAULT_REGION` environment variable. Defaults to AWS session region. |
 | `--aws-role-policy` | No | Specify an alternative IAM role policy ARN for this integration. |
+| `--permissions-boundary` | No | IAM Role PermissionsBoundary |
 
 #### Uninstall Integration
 

--- a/newrelic_lambda_cli/cli/integrations.py
+++ b/newrelic_lambda_cli/cli/integrations.py
@@ -122,7 +122,7 @@ def install(
 
     click.echo("Creating newrelic-log-ingestion Lambda function in AWS account")
     res = integrations.install_log_ingestion(
-        session, nr_license_key, enable_logs, memory_size, timeout, role_name
+        session, nr_license_key, enable_logs, memory_size, timeout, role_name, permissions_boundary,
     )
     install_success = res and install_success
 

--- a/newrelic_lambda_cli/cli/integrations.py
+++ b/newrelic_lambda_cli/cli/integrations.py
@@ -67,6 +67,11 @@ def register(group):
     metavar="<role_name>",
     show_default=False,
 )
+@click.option(
+    "--permissions-boundary",
+    default=None,
+    help="IAM Role PermissionsBoundary"
+)
 def install(
     aws_profile,
     aws_region,
@@ -80,6 +85,7 @@ def install(
     nr_region,
     timeout,
     role_name,
+    permissions_boundary,
 ):
     """Install New Relic AWS Lambda Integration"""
     session = boto3.Session(profile_name=aws_profile, region_name=aws_region)
@@ -97,7 +103,7 @@ def install(
     integrations.validate_linked_account(session, gql_client, linked_account_name)
 
     click.echo("Creating the AWS role for the New Relic AWS Lambda Integration")
-    role = integrations.create_integration_role(session, aws_role_policy, nr_account_id)
+    role = integrations.create_integration_role(session, aws_role_policy, nr_account_id, permissions_boundary)
 
     install_success = True
 

--- a/newrelic_lambda_cli/cli/integrations.py
+++ b/newrelic_lambda_cli/cli/integrations.py
@@ -193,7 +193,7 @@ def uninstall(aws_profile, aws_region, aws_permissions_check, nr_account_id, for
 @click.option(
     "--role-name",
     default=None,
-    help="The name of a new pre-created execution role for the log ingest function",
+    help="The name of a pre-created execution role for the log ingest function",
     metavar="<role_name>",
     show_default=False,
 )

--- a/newrelic_lambda_cli/cli/integrations.py
+++ b/newrelic_lambda_cli/cli/integrations.py
@@ -68,9 +68,7 @@ def register(group):
     show_default=False,
 )
 @click.option(
-    "--permissions-boundary",
-    default=None,
-    help="IAM Role PermissionsBoundary"
+    "--permissions-boundary", default=None, help="IAM Role PermissionsBoundary"
 )
 def install(
     aws_profile,
@@ -103,7 +101,9 @@ def install(
     integrations.validate_linked_account(session, gql_client, linked_account_name)
 
     click.echo("Creating the AWS role for the New Relic AWS Lambda Integration")
-    role = integrations.create_integration_role(session, aws_role_policy, nr_account_id, permissions_boundary)
+    role = integrations.create_integration_role(
+        session, aws_role_policy, nr_account_id, permissions_boundary
+    )
 
     install_success = True
 
@@ -122,7 +122,13 @@ def install(
 
     click.echo("Creating newrelic-log-ingestion Lambda function in AWS account")
     res = integrations.install_log_ingestion(
-        session, nr_license_key, enable_logs, memory_size, timeout, role_name, permissions_boundary,
+        session,
+        nr_license_key,
+        enable_logs,
+        memory_size,
+        timeout,
+        role_name,
+        permissions_boundary,
     )
     install_success = res and install_success
 

--- a/newrelic_lambda_cli/integrations.py
+++ b/newrelic_lambda_cli/integrations.py
@@ -74,7 +74,10 @@ def create_role(session, role_policy, nr_account_id, permissions_boundary):
                     "ParameterValue": str(nr_account_id),
                 },
                 {"ParameterKey": "PolicyName", "ParameterValue": role_policy_name},
-                {"ParameterKey": "PermissionsBoundary", "ParameterValue": permissions_boundary}
+                {
+                    "ParameterKey": "PermissionsBoundary",
+                    "ParameterValue": permissions_boundary,
+                },
             ],
             Capabilities=["CAPABILITY_NAMED_IAM"],
         )
@@ -93,7 +96,13 @@ def get_sar_template_url(session):
 
 
 def create_parameters(
-    nr_license_key, enable_logs, memory_size, timeout, role_name, permissions_boundary, mode="CREATE"
+    nr_license_key,
+    enable_logs,
+    memory_size,
+    timeout,
+    role_name,
+    permissions_boundary,
+    mode="CREATE",
 ):
     update_mode = mode == "UPDATE"
     parameters = [
@@ -142,10 +151,22 @@ def create_parameters(
 
 
 def import_log_ingestion_function(
-    session, nr_license_key, enable_logs, memory_size, timeout, role_name, permissions_boundary
+    session,
+    nr_license_key,
+    enable_logs,
+    memory_size,
+    timeout,
+    role_name,
+    permissions_boundary,
 ):
     parameters, capabilities = create_parameters(
-        nr_license_key, enable_logs, memory_size, timeout, role_name, permissions_boundary, "IMPORT"
+        nr_license_key,
+        enable_logs,
+        memory_size,
+        timeout,
+        role_name,
+        permissions_boundary,
+        "IMPORT",
     )
     cf_client = session.client("cloudformation")
 
@@ -178,10 +199,23 @@ def import_log_ingestion_function(
 
 
 def create_log_ingestion_function(
-    session, nr_license_key, enable_logs, memory_size, timeout, role_name, permissions_boundary, mode="CREATE"
+    session,
+    nr_license_key,
+    enable_logs,
+    memory_size,
+    timeout,
+    role_name,
+    permissions_boundary,
+    mode="CREATE",
 ):
     parameters, capabilities = create_parameters(
-        nr_license_key, enable_logs, memory_size, timeout, role_name, permissions_boundary, mode
+        nr_license_key,
+        enable_logs,
+        memory_size,
+        timeout,
+        role_name,
+        permissions_boundary,
+        mode,
     )
 
     cf_client = session.client("cloudformation")
@@ -241,7 +275,13 @@ def exec_change_set(cf_client, change_set, mode):
 
 
 def update_log_ingestion_function(
-    session, nr_license_key, enable_logs, memory_size, timeout, role_name, permissions_boundary
+    session,
+    nr_license_key,
+    enable_logs,
+    memory_size,
+    timeout,
+    role_name,
+    permissions_boundary,
 ):
     # Detect an old-style nested install and unwrap it
     client = session.client("cloudformation")

--- a/newrelic_lambda_cli/integrations.py
+++ b/newrelic_lambda_cli/integrations.py
@@ -55,7 +55,7 @@ def get_cf_stack_status(session, stack_name):
 
 
 # TODO: Merge this with create_integration_role?
-def create_role(session, role_policy, nr_account_id):
+def create_role(session, role_policy, nr_account_id, permissions_boundary):
     client = session.client("cloudformation")
     role_policy_name = "" if role_policy is None else role_policy
     stack_name = "NewRelicLambdaIntegrationRole-%d" % nr_account_id
@@ -74,6 +74,7 @@ def create_role(session, role_policy, nr_account_id):
                     "ParameterValue": str(nr_account_id),
                 },
                 {"ParameterKey": "PolicyName", "ParameterValue": role_policy_name},
+                {"ParameterKey": "PermissionsBoundary", "ParameterValue": permissions_boundary}
             ],
             Capabilities=["CAPABILITY_NAMED_IAM"],
         )
@@ -343,7 +344,7 @@ def remove_log_ingestion_function(session):
     success("Done")
 
 
-def create_integration_role(session, role_policy, nr_account_id):
+def create_integration_role(session, role_policy, nr_account_id, permissions_boundary):
     """
     Creates a AWS CloudFormation stack that adds the New Relic AWSLambda Integration
     IAM role.
@@ -356,7 +357,7 @@ def create_integration_role(session, role_policy, nr_account_id):
         return role
     stack_status = get_cf_stack_status(session, stack_name)
     if stack_status is None:
-        create_role(session, role_policy, nr_account_id)
+        create_role(session, role_policy, nr_account_id, permissions_boundary)
         role = get_role(session, role_name)
         success(
             "Created role [%s] with policy [%s] in AWS account."

--- a/newrelic_lambda_cli/templates/import-template.yaml
+++ b/newrelic_lambda_cli/templates/import-template.yaml
@@ -99,3 +99,20 @@ Resources:
           LICENSE_KEY: !Ref NRLicenseKey
           LOGGING_ENABLED: !Ref NRLoggingEnabled
           INFRA_ENABLED: !Ref NRInfraLogging
+  LambdaInvokePermissionNoCap:
+    Type: AWS::Lambda::Permission
+    Condition: NoCap
+    Properties:
+      FunctionName: !GetAtt NewRelicLogIngestionFunctionNoCap.Arn 
+      Action: lambda:InvokeFunction
+      Principal: !Sub logs.${AWS::Region}.amazonaws.com
+      SourceArn: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+
+  LambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Condition: NoRole
+    Properties:
+      FunctionName: !GetAtt NewRelicLogIngestionFunction.Arn 
+      Action: lambda:InvokeFunction
+      Principal: !Sub logs.${AWS::Region}.amazonaws.com
+      SourceArn: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*

--- a/newrelic_lambda_cli/templates/import-template.yaml
+++ b/newrelic_lambda_cli/templates/import-template.yaml
@@ -34,6 +34,9 @@ Parameters:
       IAM Role name that this function will assume. Should provide the AWSLambdaBasicExecutionRole policy. If not
       specified, an appropriate Role will be created, which will require CAPABILITY_IAM to be acknowledged.
     Default: ''
+  PermissionsBoundary:
+    Type: String
+    Description: IAM Role PermissionsBoundary (optional)
 
 Conditions:
   NoRole: !Equals ['', !Ref FunctionRole]
@@ -88,6 +91,7 @@ Resources:
       MemorySize:
         Ref: MemorySize
       Runtime: python3.7
+      PermissionsBoundary: !Ref PermissionsBoundary
       Timeout:
         Ref: Timeout
       Environment:

--- a/newrelic_lambda_cli/templates/nr-lambda-integration-role.yaml
+++ b/newrelic_lambda_cli/templates/nr-lambda-integration-role.yaml
@@ -12,7 +12,9 @@ Parameters:
     If a value is supplied a custom policy will be created with the provided name. This custom policy only includes the minimum 
     required permissions to allow NewRelic to monitor your Lambda functions. Take into account that this policy is not automatically 
     updated by AWS, and must be managed by you.'
-    
+  PermissionsBoundary:
+    Type: String
+    Description: IAM Role PermissionsBoundary (optional)
 
 Conditions: 
   UseCustomPolicy: !Not [!Equals [ !Ref PolicyName, '']]
@@ -26,6 +28,7 @@ Resources:
       ManagedPolicyArns: 
         - arn:aws:iam::aws:policy/ReadOnlyAccess
       RoleName: !Join ['_', ['NewRelicLambdaIntegrationRole', !Ref NewRelicAccountNumber]]
+      PermissionsBoundary: !Ref PermissionsBoundary
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -42,6 +45,7 @@ Resources:
     Condition: UseCustomPolicy
     Properties:
       RoleName: !Join ['_', ['NewRelicLambdaIntegrationRole', !Ref NewRelicAccountNumber]]
+      PermissionsBoundary: !Ref PermissionsBoundary
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
Add PermissionsBoundary on all created IAM Roles resources for issue #101 

Needs some cleanup and testing.. Feedback welcome.. More work coming..

Using repo-local import-role.yaml... need to add PermissionsBoundary to https://github.com/newrelic/aws-log-ingestion/blob/master/template.yaml and go back to using `get_sar_template_url()` for it to work in all regions