### PR TITLE
feat: add support for NR admin keys

### DIFF
--- a/newrelic_lambda_cli/templates/license-key-secret.yaml
+++ b/newrelic_lambda_cli/templates/license-key-secret.yaml
@@ -3,7 +3,7 @@ Parameters:
   LicenseKey:
     Type: String
     Description: The New Relic account license key
-    AllowedPattern: '(?:eu-)?[0-9a-f]+'
+    AllowedPattern: '(?:eu-)?[0-9a-f]+(?:[A-Z]{4})?'
     NoEcho: true
   SecretName:
     Type: String


### PR DESCRIPTION
For use with the `newrelic-lambda integrations install` command and the `--enable-license-key-secret` option.