### PR TITLE
fix: Append region to license key policy name

### DIFF
--- a/newrelic_lambda_cli/templates/license-key-secret.yaml
+++ b/newrelic_lambda_cli/templates/license-key-secret.yaml
@@ -31,9 +31,8 @@ Resources:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:
       ManagedPolicyName: !Sub
-        - !Ref PolicyName
-        - /
-        - { AWS::Region }
+        - ${PolicyName}-${Region}
+        - { PolicyName: !Ref PolicyName, Region: !Ref AWS::Region }
       PolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/newrelic_lambda_cli/templates/license-key-secret.yaml
+++ b/newrelic_lambda_cli/templates/license-key-secret.yaml
@@ -30,7 +30,10 @@ Resources:
   ViewNewRelicLicenseKeyPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:
-      ManagedPolicyName: !Ref PolicyName
+      ManagedPolicyName: !Sub
+        - !Ref PolicyName
+        - /
+        - { AWS::Region }
       PolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md"), "r").read()
 
 setup(
     name="newrelic-lambda-cli",
-    version="0.3.0",
+    version="0.3.1",
     python_requires=">=3.3",
     description="A CLI to install the New Relic AWS Lambda integration and layers.",
     long_description=README,


### PR DESCRIPTION
Allows for a policy for viewing the NR License Key secret in different regions. 

Closes #116 

Signed-off-by: mrickard <maurice@mauricerickard.com>