### PR TITLE
Allow Fallback to NEW_RELIC_LICENSE_KEY Environment Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,14 @@ region. By default this command will look for a default AWS profile configured v
 ```bash
 newrelic-lambda integrations install \
     --nr-account-id <account id> \
-    --nr-api-key <api key> \
-    --linked-account-name <linked account name>
+    --nr-api-key <api key>
 ```
 
 | Option | Required? | Description |
 |--------|-----------|-------------|
 | `--nr-account-id` or `-a` | Yes | The [New Relic Account ID](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id) for this integration. Can also use the `NEW_RELIC_ACCOUNT_ID` environment variable. |
 | `--nr-api-key` or `-k` | Yes | Your [New Relic User API Key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key). Can also use the `NEW_RELIC_API_KEY` environment variable. |
-| `--linked-account-name` or `-l` | Yes | A label for the New Relic Linked Account. This is how this integration will appear in New Relic. |
+| `--linked-account-name` or `-l` | No | A label for the New Relic Linked Account. This is how this integration will appear in New Relic. Defaults to "New Relic Lambda Integration - <AWS Account ID>". |
 | `--enable-logs` or `-e` | No | Enables forwarding logs to New Relic Logging. This is disabled by default. Make sure you run `newrelic-lambda subscriptions install --function ... --filter-pattern ""` afterwards. |
 | `--memory-size` or `-m` | No | Memory size (in MiB) for the New Relic log ingestion function. Default to 128MB. |
 | `--nr-region` | No | The New Relic region to use for the integration. Can use the `NEW_RELIC_REGION` environment variable. Can be either `eu` or `us`. Defaults to `us`. |
@@ -162,9 +161,11 @@ newrelic-lambda layers install \
 | `--exclude` or `-e` | No | A function name to exclude while installing layers. Can provide multiple `--exclude` arguments. Only checked when `all`, `installed` and `not-installed` are used. See `newrelic-lambda functions list` for function names. |
 | `--layer-arn` or `-l` | No | Specify a specific layer version ARN to use. This is auto detected by default. |
 | `--upgrade` or `-u` | No | Permit upgrade to the latest layer version for this region and runtime. |
-| `--enable-extension` or `-x` | No | Enable the [New Relic Lambda Extension](https://github.com/newrelic/newrelic-lambda-extension). Requires `newrelic-lambda integrations install ... --enable-license-key-secret` to set the license key secret. |
+| `--enable-extension` or `-x` | No | Enable the [New Relic Lambda Extension](https://github.com/newrelic/newrelic-lambda-extension). Requires `newrelic-lambda integrations install ... --enable-license-key-secret` to set the license key secret in AWS Secrets Manager. |
 | `--aws-profile` or `-p` | No | The AWS profile to use for this command. Can also use `AWS_PROFILE`. Will also check `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables if not using AWS CLI. |
 | `--aws-region` or `-r` | No | The AWS region this function is located. Can use `AWS_DEFAULT_REGION` environment variable. Defaults to AWS session region. |
+| `--nr-api-key` or `-k` | No | Your [New Relic User API Key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key). Can also use the `NEW_RELIC_API_KEY` environment variable. Only used if `--enable-extension` is set and there is no New Relic license key in AWS Secrets Manager. |
+| `--nr-region` | No | The New Relic region to use for the integration. Can use the `NEW_RELIC_REGION` environment variable. Can be either `eu` or `us`. Defaults to `us`. Only used if `--enable-extension` is set and there is no New Relic license key in AWS Secrets Manager. |
 
 #### Uninstall Layer
 

--- a/newrelic_lambda_cli/api.py
+++ b/newrelic_lambda_cli/api.py
@@ -18,6 +18,8 @@ import requests
 
 from newrelic_lambda_cli.cliutils import failure, success
 
+__cached_license_key = None
+
 
 class NewRelicGQL(object):
     def __init__(self, account_id, api_key, region="us"):
@@ -317,8 +319,12 @@ def validate_gql_credentials(nr_account_id, nr_api_key, nr_region):
 
 
 def retrieve_license_key(gql):
+    global __cached_license_key
+    if __cached_license_key:
+        return __cached_license_key
     try:
-        return gql.get_license_key()
+        __cached_license_key = gql.get_license_key()
+        return __cached_license_key
     except Exception:
         raise click.BadParameter(
             "Could not retrieve license key from New Relic. Check that your New Relic "

--- a/newrelic_lambda_cli/cli/integrations.py
+++ b/newrelic_lambda_cli/cli/integrations.py
@@ -48,7 +48,7 @@ def register(group):
     "-n",
     help="New Relic Linked Account Label",
     metavar="<name>",
-    required=True,
+    required=False,
 )
 @add_options(NR_OPTIONS)
 @click.option(
@@ -100,6 +100,12 @@ def install(
 
     click.echo("Retrieving integration license key")
     nr_license_key = api.retrieve_license_key(gql_client)
+
+    if not linked_account_name:
+        linked_account_name = (
+            "New Relic Lambda Integration - %s"
+            % integrations.get_aws_account_id(session)
+        )
 
     click.echo("Checking for a pre-existing link between New Relic and AWS")
     integrations.validate_linked_account(session, gql_client, linked_account_name)

--- a/newrelic_lambda_cli/cli/layers.py
+++ b/newrelic_lambda_cli/cli/layers.py
@@ -33,6 +33,23 @@ def register(group):
     required=True,
     type=click.INT,
 )
+@click.option(
+    "--nr-api-key",
+    "-k",
+    envvar="NEW_RELIC_API_KEY",
+    help="New Relic User API Key",
+    metavar="<key>",
+    required=False,
+)
+@click.option(
+    "--nr-region",
+    default="us",
+    envvar="NEW_RELIC_REGION",
+    help="New Relic Account Region",
+    metavar="<region>",
+    show_default=True,
+    type=click.Choice(["us", "eu"]),
+)
 @add_options(AWS_OPTIONS)
 @click.option(
     "functions",
@@ -73,6 +90,8 @@ def register(group):
 def install(
     ctx,
     nr_account_id,
+    nr_api_key,
+    nr_region,
     aws_profile,
     aws_region,
     aws_permissions_check,
@@ -98,6 +117,8 @@ def install(
                 function,
                 layer_arn,
                 nr_account_id,
+                nr_api_key,
+                nr_region,
                 upgrade,
                 enable_extension,
                 ctx.obj["VERBOSE"],

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -5,7 +5,9 @@ def test_add_new_relic(mock_function_config):
     config = mock_function_config("python3.7")
     assert config["Configuration"]["Handler"] == "original_handler"
 
-    update_kwargs = _add_new_relic(config, "us-east-1", None, "12345", False, True)
+    update_kwargs = _add_new_relic(
+        config, "us-east-1", None, "12345", None, False, True
+    )
     assert update_kwargs["FunctionName"] == config["Configuration"]["FunctionArn"]
     assert update_kwargs["Handler"] == "newrelic_lambda_wrapper.handler"
     assert update_kwargs["Environment"]["Variables"]["NEW_RELIC_ACCOUNT_ID"] == "12345"


### PR DESCRIPTION
Closes #120

* Adds optional `--nr-api-key` and `--nr-region` arguments to `newrelic-lambda layers install` which are necessary for license key retrieval.
* These arguments are only used if `--enable-extension` is set and no license key is available in AWS Secrets Manager.