### PR TITLE
Remove License Key regexp

### DIFF
--- a/newrelic_lambda_cli/templates/license-key-secret.yaml
+++ b/newrelic_lambda_cli/templates/license-key-secret.yaml
@@ -3,7 +3,6 @@ Parameters:
   LicenseKey:
     Type: String
     Description: The New Relic account license key
-    AllowedPattern: '(?:eu-)?[0-9a-f]+(?:[A-Z]{4})?'
     NoEcho: true
   SecretName:
     Type: String

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md"), "r").read()
 
 setup(
     name="newrelic-lambda-cli",
-    version="0.4.0",
+    version="0.4.1",
     python_requires=">=3.3",
     description="A CLI to install the New Relic AWS Lambda integration and layers.",
     long_description=README,


### PR DESCRIPTION
Apparently the license key regexp is overly restrictive. Since we fetch it from NR anyway, I think we can just remove the pattern.

Addresses LAMBDA-944