### PR TITLE
Fix Role Name Parsing For Role ARNs With Multiple Slashes

### DIFF
--- a/newrelic_lambda_cli/integrations.py
+++ b/newrelic_lambda_cli/integrations.py
@@ -25,7 +25,7 @@ def get_role(session, role_name):
     """Returns details about an IAM role"""
     # We only want the role name if an ARN is passed
     if "/" in role_name:
-        _, role_name = role_name.split("/", 1)
+        _, role_name = role_name.rsplit("/", 1)
     try:
         return session.client("iam").get_role(RoleName=role_name)
     except botocore.exceptions.ClientError as e:
@@ -292,7 +292,7 @@ def update_log_ingestion_function(
         old_props = lambda_client.get_function_configuration(
             FunctionName="newrelic-log-ingestion"
         )
-        old_role_name = old_props["Role"].split(":role/")[-1]
+        old_role_name = old_props["Role"].split("/")[-1]
         old_nr_license_key = old_props["Environment"]["Variables"]["LICENSE_KEY"]
         old_enable_logs = False
         if (

--- a/newrelic_lambda_cli/layers.py
+++ b/newrelic_lambda_cli/layers.py
@@ -299,7 +299,7 @@ def uninstall(session, function_arn, verbose):
 
 def _attach_license_key_policy(session, role_arn, policy_arn):
     """Attaches the license key secret policy to the specified role"""
-    _, role_name = role_arn.split("/", 1)
+    _, role_name = role_arn.rsplit("/", 1)
     client = session.client("iam")
     try:
         client.attach_role_policy(RoleName=role_name, PolicyArn=policy_arn)
@@ -312,7 +312,7 @@ def _attach_license_key_policy(session, role_arn, policy_arn):
 
 def _detach_license_key_policy(session, role_arn, policy_arn):
     """Detaches the license key secret policy from the specified role"""
-    _, role_name = role_arn.split("/", 1)
+    _, role_name = role_arn.rsplit("/", 1)
     client = session.client("iam")
     try:
         client.detach_role_policy(RoleName=role_name, PolicyArn=policy_arn)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md"), "r").read()
 
 setup(
     name="newrelic-lambda-cli",
-    version="0.4.7",
+    version="0.4.8",
     python_requires=">=3.3",
     description="A CLI to install the New Relic AWS Lambda integration and layers.",
     long_description=README,


### PR DESCRIPTION
Our role name parsing expects the role name to follow `:role/<role name here>` in the ARN.

But a role ARN can have a namespace like `:role/foobar/barbaz`.

This update handles that case correctly.