### PR TITLE
Output CloudFormation Waiter Failure Status Reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,22 +60,20 @@ manual function wrapping is required using the runtime specific New Relic agent.
 ## Installation
 
 ```bash
-pip install newrelic-lambda-cli
+pip3 install newrelic-lambda-cli
 ```
 
 Or clone this repo and run:
 
 ```bash
-python setup.py install
+python3 setup.py install
 ```
 
 To update the CLI, run:
 
 ```
-pip install --upgrade newrelic-lambda-cli
+pip3 install --upgrade newrelic-lambda-cli
 ```
-
-**Note:** You may need to use `python3` and/or `pip3` in the commands above if you have Python 2.7 installed.
 
 ## Usage
 
@@ -282,7 +280,7 @@ python setup.py test
 **Upgrade the CLI**: A good first step, as we push updates frequently.
 
 ```
-pip install --upgrade newrelic-lambda-cli
+pip3 install --upgrade newrelic-lambda-cli
 ```
 
 **UnrecognizedClientException**:

--- a/README.md
+++ b/README.md
@@ -309,3 +309,11 @@ Traceback (most recent call last):
 IndexError: list index out of range`
 
 This error can happen if you have an existing AWS integration, and are running `newrelic-lambda integrations install` with a different `--linked-account-name` (for instance, to add a new region to the integration). The linked account name can be whatever you want it to be, but needs to be consistent with the previously linked AWS account.
+
+**AWS Secrets Manager Secret Name Conflict**
+This CLI manages a AWS Secrets Manager secret with the name `NEW_RELIC_LICENSE_KEY`. If
+you run into a CloudFormation error reporting that this secret already exists, make
+sure that you delete any existing secrets and try again. Keep in mind, by default in the
+AWS console when you delete a secret from AWS Secrets Manager that it will not delete
+the secret permnantly for several days. You will need to perform a "force delete without
+recovery" when deleting the secret to avoid this naming conflict.

--- a/newrelic_lambda_cli/integrations.py
+++ b/newrelic_lambda_cli/integrations.py
@@ -346,6 +346,7 @@ def update_log_ingestion_function(input):
             )
         except botocore.exceptions.WaiterError as e:
             failure(e.last_response["Status"]["StatusReason"])
+            raise e
         else:
             success("Done")
 
@@ -359,6 +360,7 @@ def update_log_ingestion_function(input):
             client.get_waiter("stack_delete_complete").wait(StackName=INGEST_STACK_NAME)
         except botocore.exceptions.WaiterError as e:
             failure(e.last_response["Status"]["StatusReason"])
+            raise e
         else:
             success("Done")
 
@@ -546,6 +548,7 @@ def update_log_ingestion(input):
             % input.session.region_name
         )
         return False
+
     stack_status = _check_for_ingest_stack(input.session)
     if stack_status is None:
         failure(
@@ -556,6 +559,7 @@ def update_log_ingestion(input):
             "run 'newrelic-lambda integrations install'." % input.session.region_name
         )
         return False
+
     try:
         update_log_ingestion_function(input)
     except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md"), "r").read()
 
 setup(
     name="newrelic-lambda-cli",
-    version="0.5.1",
+    version="0.5.2",
     python_requires=">=3.3",
     description="A CLI to install the New Relic AWS Lambda integration and layers.",
     long_description=README,


### PR DESCRIPTION
To make it easier to debug why a CloudFormation change set failed, output the status reason.