### PR TITLE
Make Integration Linking Based On IDs, Surface Role ARN

### DIFF
--- a/newrelic_lambda_cli/api.py
+++ b/newrelic_lambda_cli/api.py
@@ -130,16 +130,6 @@ class NewRelicGQL(object):
         except KeyError:
             return None
 
-    def get_linked_account_by_name(self, account_name):
-        """
-        return a specific linked account of the New Relic account by name
-        """
-        accounts = self.get_linked_accounts()
-        try:
-            return next((a for a in accounts if a["name"] == account_name), None)
-        except KeyError:
-            return None
-
     def link_account(self, role_arn, account_name):
         """
         create a linked account (cloud integrations account)

--- a/newrelic_lambda_cli/api.py
+++ b/newrelic_lambda_cli/api.py
@@ -67,8 +67,6 @@ class NewRelicGQL(object):
                     linkedAccounts {
                       id
                       name
-                      createdAt
-                      updatedAt
                       authLabel
                       externalId
                     }
@@ -116,7 +114,7 @@ class NewRelicGQL(object):
         """
         accounts = self.get_linked_accounts()
         try:
-            return next((a for a in accounts if a["id"] == id), None)
+            return next((a for a in accounts if a["id"] == int(id)), None)
         except KeyError:
             return None
 
@@ -142,6 +140,8 @@ class NewRelicGQL(object):
                 linkedAccounts {
                   id
                   name
+                  authLabel
+                  externalId
                 }
                 errors {
                     message

--- a/newrelic_lambda_cli/cli/integrations.py
+++ b/newrelic_lambda_cli/cli/integrations.py
@@ -114,7 +114,7 @@ def install(ctx, **kwargs):
     if not input.linked_account_name:
         input = input._replace(
             linked_account_name=(
-                "New Relic Lambda Integration - %s"
+                "New Relic AWS Integration - %s"
                 % integrations.get_aws_account_id(input.session)
             )
         )
@@ -142,9 +142,13 @@ def install(ctx, **kwargs):
         res = api.create_integration_account(gql_client, input, role)
         install_success = res and install_success
 
-        click.echo("Enabling Lambda integration on the link between New Relic and AWS")
-        res = api.enable_lambda_integration(gql_client, input)
-        install_success = res and install_success
+        linked_account_id = res.get("id")
+        if linked_account_id:
+            click.echo(
+                "Enabling Lambda integration on the link between New Relic and AWS"
+            )
+            res = api.enable_lambda_integration(gql_client, input, linked_account_id)
+            install_success = res and install_success
 
     if input.enable_license_key_secret:
         click.echo("Creating the managed secret for the New Relic License Key")

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -95,3 +95,23 @@ def unique(seq):
     # than resolving a local variable.
     seen_add = seen.add
     return [x for x in seq if not (x in seen or seen_add(x))]
+
+
+def parse_arn(arn):
+    # http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+    elements = arn.split(":")
+    result = {
+        "arn": elements[0],
+        "partition": elements[1],
+        "service": elements[2],
+        "region": elements[3],
+        "account": elements[4],
+    }
+    if len(elements) == 7:
+        result["resourcetype"], result["resource"] = elements[5:]
+    elif "/" not in elements[5]:
+        result["resource"] = elements[5]
+        result["resourcetype"] = None
+    else:
+        result["resourcetype"], result["resource"] = elements[5].split("/")
+    return result

--- a/tests/cli/test_integrations.py
+++ b/tests/cli/test_integrations.py
@@ -42,7 +42,7 @@ def test_integrations_install(
             call.validate_gql_credentials(ANY),
             call.retrieve_license_key(ANY),
             call.create_integration_account(ANY, ANY, ANY),
-            call.enable_lambda_integration(ANY, ANY),
+            call.enable_lambda_integration(ANY, ANY, ANY),
         ],
         any_order=True,
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,146 @@
+from unittest.mock import Mock
+
+from newrelic_lambda_cli.api import (
+    create_integration_account,
+    enable_lambda_integration,
+    NewRelicGQL,
+)
+
+from .conftest import integration_install
+
+
+def test_create_integration_account():
+    mock_gql = NewRelicGQL("123456789", "foobar")
+    mock_gql.query = Mock(
+        return_value={
+            "actor": {
+                "account": {
+                    "cloud": {
+                        "linkedAccounts": [
+                            {
+                                "authLabel": "arn:aws:iam::123456789:role/FooBar",
+                                "externalId": "123456789",
+                                "name": "Foo Bar",
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    )
+    input = integration_install(nr_account_id=123456789, linked_account_name="Foo Bar")
+    role = {"Role": {"Arn": "arn:aws:iam::123456789:role/FooBar"}}
+
+    assert create_integration_account(mock_gql, input, role) == {
+        "authLabel": "arn:aws:iam::123456789:role/FooBar",
+        "externalId": "123456789",
+        "name": "Foo Bar",
+    }
+
+    mock_gql.query = Mock(
+        side_effect=(
+            {"actor": {"account": {"cloud": {"linkedAccounts": []}}}},
+            {
+                "cloudLinkAccount": {
+                    "linkedAccounts": [
+                        {
+                            "authLabel": "arn:aws:iam::123456789:role/FooBar",
+                            "externalId": "123456789",
+                            "name": "Foo Bar",
+                        }
+                    ]
+                }
+            },
+        )
+    )
+
+    assert create_integration_account(mock_gql, input, role) == {
+        "authLabel": "arn:aws:iam::123456789:role/FooBar",
+        "externalId": "123456789",
+        "name": "Foo Bar",
+    }
+
+
+def test_enable_lambda_integration():
+    mock_gql = NewRelicGQL("123456789", "foobar")
+    mock_gql.query = Mock(
+        return_value={"actor": {"account": {"cloud": {"linkedAccounts": []}}}},
+    )
+    input = integration_install(nr_account_id=123456789, linked_account_name="Foo Bar")
+
+    assert enable_lambda_integration(mock_gql, input, 123456789) is False
+
+    mock_gql.query = Mock(
+        side_effect=(
+            {
+                "actor": {
+                    "account": {
+                        "cloud": {
+                            "linkedAccounts": [
+                                {
+                                    "authLabel": "arn:aws:iam::123456789:role/FooBar",
+                                    "externalId": "123456789",
+                                    "id": 123456789,
+                                    "name": "Foo Bar",
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "actor": {
+                    "account": {
+                        "cloud": {
+                            "linkedAccount": {
+                                "integrations": [
+                                    {"service": {"isEnabled": True, "slug": "lambda"}}
+                                ]
+                            }
+                        }
+                    },
+                }
+            },
+        )
+    )
+
+    assert enable_lambda_integration(mock_gql, input, 123456789) is True
+
+    mock_gql.query = Mock(
+        side_effect=(
+            {
+                "actor": {
+                    "account": {
+                        "cloud": {
+                            "linkedAccounts": [
+                                {
+                                    "authLabel": "arn:aws:iam::123456789:role/FooBar",
+                                    "externalId": "123456789",
+                                    "id": 123456789,
+                                    "name": "Foo Bar",
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "actor": {
+                    "account": {"cloud": {"linkedAccount": {"integrations": []}}},
+                }
+            },
+            {
+                "cloudConfigureIntegration": {
+                    "integrations": [
+                        {
+                            "id": 123456789,
+                            "name": "Foo Bar",
+                            "service": {"isEnabled": True, "slug": "lambda"},
+                        }
+                    ]
+                }
+            },
+        )
+    )
+
+    assert enable_lambda_integration(mock_gql, input, 123456789) is True

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import boto3
 import botocore
-from moto import mock_cloudformation, mock_iam
+from moto import mock_cloudformation, mock_iam, mock_sts
 import pytest
 from unittest.mock import call, patch, MagicMock, ANY
 
@@ -17,6 +17,7 @@ from newrelic_lambda_cli.integrations import (
     install_license_key,
     remove_license_key,
     _get_license_key_policy_arn,
+    get_aws_account_id,
 )
 
 from .conftest import integration_install, integration_uninstall, integration_update
@@ -299,3 +300,9 @@ def test__import_log_ingestion_function(aws_credentials):
             ),
             "foobar",
         )
+
+
+@mock_sts
+def test_get_aws_account_id(aws_credentials):
+    session = boto3.Session(region_name="us-east-1")
+    assert get_aws_account_id(session) == "123456789012"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,10 @@
+from newrelic_lambda_cli.utils import parse_arn
+
+
+def test_parse_arn():
+    result = parse_arn("arn:aws:iam:us-east-1:123456789:role/FooBar")
+
+    assert result["partition"] == "aws"
+    assert result["service"] == "iam"
+    assert result["region"] == "us-east-1"
+    assert result["account"] == "123456789"


### PR DESCRIPTION
In addition to surfacing an existing cloud integration's IAM role ARN if found, this change also cleans up the lookup logic for cloud integrations in general to make it based on IDs instead of names. Link account names have been problematic as they are arbitrary and are not unique.