### PR TITLE
Add get_linked_account_by_name Back For Validation

### DIFF
--- a/newrelic_lambda_cli/api.py
+++ b/newrelic_lambda_cli/api.py
@@ -128,6 +128,16 @@ class NewRelicGQL(object):
         except KeyError:
             return None
 
+    def get_linked_account_by_name(self, name):
+        """
+        return a specific linked account of the New Relic account by name
+        """
+        accounts = self.get_linked_accounts()
+        try:
+            return next((a for a in accounts if a["name"] == name), None)
+        except KeyError:
+            return None
+
     def link_account(self, role_arn, account_name):
         """
         create a linked account (cloud integrations account)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md"), "r").read()
 
 setup(
     name="newrelic-lambda-cli",
-    version="0.5.3",
+    version="0.5.4",
     python_requires=">=3.3",
     description="A CLI to install the New Relic AWS Lambda integration and layers.",
     long_description=README,


### PR DESCRIPTION
This method was removed by #150, but is still required by profile validation.

Closes #151