### PR TITLE
Kwest/lambda 1197

### DIFF
--- a/newrelic_lambda_cli/cli/layers.py
+++ b/newrelic_lambda_cli/cli/layers.py
@@ -174,6 +174,15 @@ def install(ctx, **kwargs):
     metavar="<name>",
     multiple=True,
 )
+@click.option(
+    "--nr-account-id",
+    "-a",
+    envvar="NEW_RELIC_ACCOUNT_ID",
+    help="New Relic Account ID",
+    metavar="<account_id>",
+    required=False,
+    type=click.INT,
+)
 @click.pass_context
 def uninstall(ctx, **kwargs):
     """Uninstall New Relic AWS Lambda Layers"""

--- a/newrelic_lambda_cli/types.py
+++ b/newrelic_lambda_cli/types.py
@@ -69,6 +69,7 @@ LAYER_UNINSTALL_KEYS = [
     "aws_permissions_check",
     "functions",
     "excludes",
+    "nr_account_id",
 ]
 
 SUBSCRIPTION_INSTALL_KEYS = [

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -147,3 +147,7 @@ def parse_arn(arn):
 
 def supports_lambda_extension(runtime):
     return RUNTIME_CONFIG.get(runtime, {}).get("LambdaExtension", False)
+
+
+def format_account_id_string(stack_name, account_id):
+    return "{0}-{1}".format(stack_name, str(account_id))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,12 @@ def _mock_function_config(runtime):
             "Layers": [{"Arn": "existing_layer_arn"}],
             "FunctionName": "aws-python3-dev-hello",
             "FunctionArn": "arn:aws:lambda:us-east-1:5558675309:function:aws-python3-dev-hello",  # noqa
-            "Environment": {"Variables": {"EXISTING_ENV_VAR": "Hello World"}},
+            "Environment": {
+                "Variables": {
+                    "EXISTING_ENV_VAR": "Hello World",
+                    "NEW_RELIC_ACCOUNT_ID": 123,
+                }
+            },
             "Handler": "original_handler",
             "Runtime": runtime,
         }

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -288,6 +288,8 @@ def test_remove_new_relic(aws_credentials, mock_function_config):
         "NEW_RELIC_LAMBDA_HANDLER"
     ] = "original_handler"
 
+    config["Configuration"]["Environment"]["Variables"]["NEW_RELIC_ACCOUNT_ID"] = 123
+
     update_kwargs = _remove_new_relic(
         layer_uninstall(session=session, aws_region="us-east-1"), config
     )
@@ -396,6 +398,7 @@ def test_uninstall(aws_credentials, mock_function_config):
     config["Configuration"]["Environment"]["Variables"][
         "NEW_RELIC_LAMBDA_HANDLER"
     ] = "foobar.handler"
+    config["Configuration"]["Environment"]["Variables"]["NEW_RELIC_ACCOUNT_ID"] = 123
     config["Configuration"]["Layers"] = [{"Arn": get_arn_prefix("us-east-1")}]
     assert uninstall(layer_uninstall(session=mock_session), "foobarbaz") is True
 


### PR DESCRIPTION
https://newrelic.atlassian.net/browse/LAMBDA-1197

Resolving managed secret issue where the wrong license key is used for regions that already have the secret stack installed. We do not check for the license key value due to privileges and instead just check for the stack existence. 
Now we format the stack name as `NewRelicLicenseKeySecret-{nr_account_id}` and check for the existence of that. 

This update has been made for the integration commands and the layer commands. 

This name format change has also been made for the PolicyName: 
`{PolicyName}-{nr_account_id}`
and the SecretName:
`NEW_RELIC_LICENSE_KEY-{nr_account_id}`

This is required for a few reasons.
For the secret name, you need a uniquely named secret for each license key value within a region. Therefore we have to differentiate between the different stored keys. The same applies for the policy, Also, for detaching the policy when uninstalling the layer/nr integration we need to make sure we're removing the correct policy. 