### PR TITLE
Kwest/lambda 1197

### DIFF
--- a/newrelic_lambda_cli/integrations.py
+++ b/newrelic_lambda_cli/integrations.py
@@ -50,14 +50,19 @@ def _get_cf_stack_status(session, stack_name, nr_account_id=None):
     try:
         res = session.client("cloudformation").describe_stacks(StackName=stack_name)
         if nr_account_id is not None:
-            (stack_nr_account_id,) = _get_stack_output_value(session, ["NrAccountId"])
-            if str(nr_account_id) not in stack_nr_account_id:
+            stack_output_account_id = _get_stack_output_value(session, ["NrAccountId"])
+            # Checking length of outputs here to protect against installs done with older CLI versions.
+            # We don't want to constantly warn users who installed on previous versions with no outputs.
+            if (
+                len(stack_output_account_id) > 0
+                and str(nr_account_id) not in stack_output_account_id
+            ):
                 warning(
                     "WARNING: Managed secret already exists in this region for New Relic account {0}.\n"
                     "Current CLI behavior limits the setup of one managed secret per region.\n"
                     "To set up an additional secret for New Relic account {1} see our docs:\n{2}.\n"
                     "Or run this command with --disable-license-key-secret to avoid attemping to create a new managed secret.".format(
-                        stack_nr_account_id, nr_account_id, NR_DOCS_ACT_LINKING_URL
+                        stack_output_account_id, nr_account_id, NR_DOCS_ACT_LINKING_URL
                     )
                 )
 

--- a/newrelic_lambda_cli/templates/license-key-secret.yaml
+++ b/newrelic_lambda_cli/templates/license-key-secret.yaml
@@ -18,6 +18,9 @@ Parameters:
   ViewPolicyExportName:
     Type: String
     Default: NewRelic-ViewLicenseKeyPolicyARN
+  NrAccountId:
+    Type: String
+    Default: NEW_RELIC_ACCOUNT_ID
 
 Resources:
   LicenseKeySecret:
@@ -25,7 +28,7 @@ Resources:
     Properties:
       Description: The New Relic license key, for sending telemetry
       Name: !Sub "${SecretName}"
-      SecretString: !Sub '{ "LicenseKey": "${LicenseKey}" }'
+      SecretString: !Sub '{ "LicenseKey": "${LicenseKey}", "NrAccountId": "${NrAccountId}" }'
   ViewNewRelicLicenseKeyPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:
@@ -51,3 +54,7 @@ Outputs:
     Value: !Ref ViewNewRelicLicenseKeyPolicy
     Export:
       Name: !Sub "${AWS::StackName}-${ViewPolicyExportName}"
+  NrAccountId:
+    Value: !Ref NrAccountId
+    Export:
+      Name: !Sub "${NrAccountId}"

--- a/newrelic_lambda_cli/templates/license-key-secret.yaml
+++ b/newrelic_lambda_cli/templates/license-key-secret.yaml
@@ -20,7 +20,6 @@ Parameters:
     Default: NewRelic-ViewLicenseKeyPolicyARN
   NrAccountId:
     Type: String
-    Default: NEW_RELIC_ACCOUNT_ID
 
 Resources:
   LicenseKeySecret:
@@ -57,4 +56,4 @@ Outputs:
   NrAccountId:
     Value: !Ref NrAccountId
     Export:
-      Name: !Sub "${NrAccountId}"
+      Name: !Sub "${AWS::StackName}-NrAccountId"

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -6,6 +6,7 @@ import boto3
 import botocore
 import click
 
+NR_DOCS_ACT_LINKING_URL = "https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking/#manually-configuring-the-license-key-secret"
 NEW_RELIC_ARN_PREFIX_TEMPLATE = "arn:aws:lambda:%s:451483290750"
 RUNTIME_CONFIG = {
     "dotnetcore3.1": {"LambdaExtension": True},

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md"), "r").read()
 
 setup(
     name="newrelic-lambda-cli",
-    version="0.5.5",
+    version="0.6.0",
     python_requires=">=3.3",
     description="A CLI to install the New Relic AWS Lambda integration and layers.",
     long_description=README,


### PR DESCRIPTION
Per meeting on Tuesday:
- Add additional logging for integrations command to notify customer when managed secret isn't set up for the account id they're using. 
- Add an error during layers command when NR Account id doesn't match one stored in secret.
- In warning and error messages point users to updated docs that outline how to manually set up managed secret. 
- Add key/val of account id associated with stored license key in secret manager.
https://newrelic.atlassian.net/browse/LAMBDA-1197