### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.7-alpine
-RUN adduser -D -s /bin/bash newrelic-lambda-cli
+FROM python:3.7-slim
+RUN useradd -r -u 1000 newrelic-lambda-cli
 USER newrelic-lambda-cli
 WORKDIR /home/newrelic-lambda-cli
 RUN pip3 install -U newrelic-lambda-cli --user


### PR DESCRIPTION
Alpine uses musl instead of libc and the wheel build was failing. Instead of digging up all the dev dependencies needed for musl to compile a wheel, I'm just switching this to libc which will  install the precompiled wheel.