### PR TITLE
fix: Python 3.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * python3.6
 * python3.7
 * python3.8
+* python3.9
 
 **Note:** Automatic handler wrapping is only supported for Node.js and Python. For other runtimes,
 manual function wrapping is required using the runtime specific New Relic agent.

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -48,6 +48,10 @@ RUNTIME_CONFIG = {
         "Handler": "newrelic_lambda_wrapper.handler",
         "LambdaExtension": True,
     },
+    "python3.9": {
+        "Handler": "newrelic_lambda_wrapper.handler",
+        "LambdaExtension": True,
+    },
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38','py39']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,7 @@ def test_error():
 
 def test_is_valid_handler():
     assert is_valid_handler("fakeruntime", "not.a.valid.handler") is False
-    assert is_valid_handler("python3.8", "newrelic_lambda_wrapper.handler") is True
+    assert is_valid_handler("python3.9", "newrelic_lambda_wrapper.handler") is True
 
 
 def test_parse_arn():
@@ -86,6 +86,7 @@ def test_supports_lambda_extension():
             "provided.al2",
             "python3.7",
             "python3.8",
+            "python3.9",
         )
     )
     assert not any(


### PR DESCRIPTION
Adding Python 3.9 references to utils, tests, readme, and pyproject.toml

Signed-off-by: mrickard <maurice@mauricerickard.com>