### PR TITLE
Detect TTY, Go Into Non-Interactive Mode If Not TTY

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md"), "r").read()
 
 setup(
     name="newrelic-lambda-cli",
-    version="0.6.5",
+    version="0.6.6",
     python_requires=">=3.3",
     description="A CLI to install the New Relic AWS Lambda integration and layers.",
     long_description=README,


### PR DESCRIPTION
Closes #184 #185
 
The selection prompt breaks when not in a terminal emulator / pseudo tty.

This checks for a tty and reverts to the old non-interactive behavior if not running in a tty.