### PR TITLE
Fix : Invalid type for parameter Layers[0]

### DIFF
--- a/newrelic_lambda_cli/layers.py
+++ b/newrelic_lambda_cli/layers.py
@@ -123,7 +123,7 @@ def _add_new_relic(input, config, nr_license_key):
     new_relic_layer = []
 
     if input.layer_arn:
-        new_relic_layer = [input.layer_arn]
+        new_relic_layer = input.layer_arn
     else:
         # discover compatible layers...
         available_layers = index(aws_region, runtime, architecture)


### PR DESCRIPTION
Error: Unexpected AWS error: Parameter validation failed:
Invalid type for parameter Layers[0], value: ['arn:aws:lambda:REDACTED:REDACTED:layer:NewRelicPython38:60'], type: <class 'list'>, valid types: <class 'str'>