### PR TITLE
[WIP] Function Name Length Validation

### DIFF
--- a/newrelic_lambda_cli/functions.py
+++ b/newrelic_lambda_cli/functions.py
@@ -39,6 +39,12 @@ def list_functions(session, filter=None):
 def get_function(session, function_name):
     """Returns details about an AWS lambda function"""
     try:
+        if len(function_name) > 170 or len(function_name) == 0:
+            raise click.UsageError(
+                str(
+                    "Lambda Function name does not meet constraints ref: https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html#API_GetFunction_RequestSyntax"
+                )
+            )
         return session.client("lambda").get_function(FunctionName=function_name)
     except botocore.exceptions.ClientError as e:
         if (

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,8 +2,13 @@ import boto3
 from unittest import mock
 from moto import mock_lambda
 from unittest.mock import MagicMock
+from click import UsageError
 
-from newrelic_lambda_cli.functions import get_aliased_functions, list_functions
+from newrelic_lambda_cli.functions import (
+    get_aliased_functions,
+    get_function,
+    list_functions,
+)
 
 from .conftest import layer_install
 
@@ -75,3 +80,30 @@ def test_list_functions(aws_credentials):
     assert list(list_functions(mock_session)) == [
         {"FunctionName": "foobar", "Layers": [], "x-new-relic-enabled": False}
     ]
+
+
+@mock_lambda
+def test_get_function(aws_credentials):
+    session = boto3.Session(region_name="us-east-1")
+    string_too_big = "gexiwyttrlcyzjggibmfmbapercbmxdcgnkgfeqsdsxobmmyeheiryfxatutvljoxlglhfwctgrqloquyhffpaqdugyeiolixxrwxbrkupiugndognrrtfuzkqbaipfjwvggthgvtoziqlfugybrjikgoxzjszasahemcntjeqnmac"
+    string_too_small = ""
+    err_too_big = None
+    try:
+        get_function(session, string_too_big)
+    except UsageError as ex:
+        err_too_big = ex
+    assert type(err_too_big) == UsageError
+    err_too_small = None
+    try:
+        get_function(session, string_too_small)
+    except UsageError as ex:
+        err_too_small = ex
+    assert type(err_too_small) == UsageError
+    # session = boto3.Session(region_name="us-east-1")
+    # assert get_function(session, 'foobar') == None
+    # mock_session = MagicMock()
+    # mock_client = mock_session.return_value
+    # mock_get_function = mock_client.get_function.return_value
+    # mock_get_function.return_value = {"Configuration": { "FunctionName": "foobar"}, "Code": {}, "Tags": {}, "Concurrency": {}}
+    # mock_result = get_function(mock_session, 'foobar')
+    # assert mock_result.return_value == 'foobar'


### PR DESCRIPTION
This project is awesome! :guitar: :100:

Wanted to collect some input and create this as a draft PR.

Was thinking about how there are upper & lower bounds to an AWS Lambda Function's Name/ARN/Name:Alias length - wanted to collect thoughts on a draft PR if it was worth implementing both an Upper and Lower bound validation on the string that the CLI tool sees - vs just calling out to the Boto3 package without an validation of input.

Would this level of input validation be of any value?  Thanks for the input!

I'd be more than open to close this draft out, expand it, iterate or what-have-ya! 
:smile: 