### PR TITLE
Small Refactor On NR Function Name

### DIFF
--- a/newrelic_lambda_cli/constants.py
+++ b/newrelic_lambda_cli/constants.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class Constants(Enum):
+    NR_LOG_FUNC = "newrelic-log-ingestion"

--- a/newrelic_lambda_cli/functions.py
+++ b/newrelic_lambda_cli/functions.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from asyncio.proactor_events import constants
 import botocore
 import click
 
@@ -10,6 +11,7 @@ from newrelic_lambda_cli.types import (
     SubscriptionUninstall,
 )
 from newrelic_lambda_cli import utils
+from newrelic_lambda_cli.constants import Constants
 
 
 @utils.catch_boto_errors
@@ -71,7 +73,7 @@ def get_aliased_functions(input):
         function
         for function in input.functions
         if function.lower()
-        not in ("all", "installed", "not-installed", "newrelic-log-ingestion")
+        not in ("all", "installed", "not-installed", Constants.NR_LOG_FUNC.value)
         and function not in input.excludes
     ]
 
@@ -82,7 +84,7 @@ def get_aliased_functions(input):
         for function in list_functions(input.session, alias):
             if (
                 "FunctionName" in function
-                and "newrelic-log-ingestion" not in function["FunctionName"]
+                and Constants.NR_LOG_FUNC.value not in function["FunctionName"]
                 and function["FunctionName"] not in input.excludes
             ):
                 functions.append(function["FunctionName"])

--- a/newrelic_lambda_cli/functions.py
+++ b/newrelic_lambda_cli/functions.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from asyncio.proactor_events import constants
 import botocore
 import click
 

--- a/newrelic_lambda_cli/integrations.py
+++ b/newrelic_lambda_cli/integrations.py
@@ -15,6 +15,7 @@ from newrelic_lambda_cli.types import (
     IntegrationUpdate,
 )
 from newrelic_lambda_cli.utils import catch_boto_errors, NR_DOCS_ACT_LINKING_URL
+from newrelic_lambda_cli.constants import Constants
 
 INGEST_STACK_NAME = "NewRelicLogIngestion"
 LICENSE_KEY_STACK_NAME = "NewRelicLicenseKeySecret"
@@ -215,7 +216,7 @@ def _import_log_ingestion_function(input, nr_license_key):
                 {
                     "ResourceType": "AWS::Lambda::Function",
                     "LogicalResourceId": "NewRelicLogIngestionFunctionNoCap",
-                    "ResourceIdentifier": {"FunctionName": "newrelic-log-ingestion"},
+                    "ResourceIdentifier": {"FunctionName": Constants.NR_LOG_FUNC.value},
                 }
             ],
         )
@@ -334,7 +335,7 @@ def update_log_ingestion_function(input):
         # We can't change props during import, so let's set them to their current values
         lambda_client = input.session.client("lambda")
         old_props = lambda_client.get_function_configuration(
-            FunctionName="newrelic-log-ingestion"
+            FunctionName=Constants.NR_LOG_FUNC.value
         )
         old_role_name = old_props["Role"].split("/")[-1]
         old_nr_license_key = old_props["Environment"]["Variables"]["LICENSE_KEY"]
@@ -508,7 +509,7 @@ def install_log_ingestion(
     Returns True for success and False for failure.
     """
     assert isinstance(input, IntegrationInstall)
-    function = get_function(input.session, "newrelic-log-ingestion")
+    function = get_function(input.session, Constants.NR_LOG_FUNC.value)
     if function is None:
         stack_status = _check_for_ingest_stack(input.session)
         if stack_status is None:
@@ -549,7 +550,7 @@ def update_log_ingestion(input):
     """
     assert isinstance(input, IntegrationUpdate)
 
-    function = get_function(input.session, "newrelic-log-ingestion")
+    function = get_function(input.session, Constants.NR_LOG_FUNC.value)
     if function is None:
         failure(
             "No 'newrelic-log-ingestion' function in region '%s'. "
@@ -583,7 +584,7 @@ def get_log_ingestion_license_key(session):
     """
     Fetches the license key value from the log ingestion function
     """
-    function = get_function(session, "newrelic-log-ingestion")
+    function = get_function(session, Constants.NR_LOG_FUNC.value)
     if function:
         return function["Configuration"]["Environment"]["Variables"]["LICENSE_KEY"]
     return None

--- a/newrelic_lambda_cli/subscriptions.py
+++ b/newrelic_lambda_cli/subscriptions.py
@@ -10,6 +10,7 @@ from newrelic_lambda_cli.types import (
     SubscriptionInstall,
     SubscriptionUninstall,
 )
+from newrelic_lambda_cli.constants import Constants
 from newrelic_lambda_cli.utils import catch_boto_errors
 
 
@@ -83,7 +84,7 @@ def _remove_subscription_filter(session, function_name, filter_name):
 @catch_boto_errors
 def create_log_subscription(input, function_name):
     assert isinstance(input, SubscriptionInstall)
-    destination = get_function(input.session, "newrelic-log-ingestion")
+    destination = get_function(input.session, Constants.NR_LOG_FUNC.value)
     if destination is None:
         failure(
             "Could not find 'newrelic-log-ingestion' function. Is the New Relic AWS "

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -6,6 +6,8 @@ import boto3
 import botocore
 import click
 
+from enum import Enum
+
 NR_DOCS_ACT_LINKING_URL = "https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking/#manually-configuring-the-license-key-secret"
 NEW_RELIC_ARN_PREFIX_TEMPLATE = "arn:aws:lambda:%s:451483290750"
 RUNTIME_CONFIG = {

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -4,6 +4,7 @@ from moto import mock_lambda
 from unittest.mock import MagicMock
 
 from newrelic_lambda_cli.functions import get_aliased_functions, list_functions
+from newrelic_lambda_cli.constants import Constants
 
 from .conftest import layer_install
 
@@ -47,7 +48,7 @@ def test_get_aliased_functions(mock_list_functions, aws_credentials):
     mock_list_functions.return_value = [
         {"FunctionName": "aliased-func"},
         {"FunctionName": "ignored-func"},
-        {"FunctionName": "newrelic-log-ingestion"},
+        {"FunctionName": Constants.NR_LOG_FUNC.value},
     ]
     assert get_aliased_functions(
         layer_install(


### PR DESCRIPTION
## Why this PR?

- just a small refactor to dry hardcoding of the new relic log ingestion function around the tool
- offers flexibility should the function name ever change, would just require a change to a single file vs search/replace on multiple files