### PR TITLE
Grant Ability for Users to find their installed version of the newrelic-log-ingestion function in their AWS ecosystem

### DIFF
--- a/newrelic_lambda_cli/cli/integrations.py
+++ b/newrelic_lambda_cli/cli/integrations.py
@@ -8,6 +8,7 @@ from newrelic_lambda_cli.types import (
     IntegrationInstall,
     IntegrationUninstall,
     IntegrationUpdate,
+    IntegrationLogFunctionVersion,
 )
 from newrelic_lambda_cli.cli.decorators import add_options, AWS_OPTIONS, NR_OPTIONS
 from newrelic_lambda_cli.cliutils import done, failure
@@ -24,6 +25,25 @@ def register(group):
     integrations_group.add_command(install)
     integrations_group.add_command(uninstall)
     integrations_group.add_command(update)
+    integrations_group.add_command(get_log_function_version)
+
+
+@click.command(name="get-log-function-version")
+@add_options(AWS_OPTIONS)
+@click.pass_context
+def get_log_function_version(ctx, **kwargs):
+    """Fetch New Relic Log Ingest Function Version"""
+    input = IntegrationLogFunctionVersion(session=None, **kwargs)
+    input = input._replace(
+        session=boto3.Session(
+            profile_name=input.aws_profile, region_name=input.aws_region
+        )
+    )
+    click.echo(
+        "Fetching newrelic-log-ingestion version(s) that may exist in AWS account"
+    )
+    integrations.get_log_function_version(input)
+    pass
 
 
 @click.command(name="install")

--- a/newrelic_lambda_cli/types.py
+++ b/newrelic_lambda_cli/types.py
@@ -43,6 +43,13 @@ INTEGRATION_UPDATE_KEYS = [
     "tags",
 ]
 
+INTEGRATION_LOG_FUNCTION_VERSION_KEYS = [
+    "session",
+    "aws_profile",
+    "aws_region",
+    "aws_permissions_check",
+]
+
 LAYER_INSTALL_KEYS = [
     "session",
     "verbose",
@@ -94,6 +101,10 @@ SUBSCRIPTION_UNINSTALL_KEYS = [
 IntegrationInstall = namedtuple("IntegrationInstall", INTEGRATION_INSTALL_KEYS)
 IntegrationUninstall = namedtuple("IntegrationUninstall", INTEGRATION_UNINSTALL_KEYS)
 IntegrationUpdate = namedtuple("IntegrationUpdate", INTEGRATION_UPDATE_KEYS)
+IntegrationLogFunctionVersion = namedtuple(
+    "IntegrationLogFunctionVersion", INTEGRATION_LOG_FUNCTION_VERSION_KEYS
+)
+
 
 LayerInstall = namedtuple("LayerInstall", LAYER_INSTALL_KEYS)
 LayerUninstall = namedtuple("LayerUninstall", LAYER_UNINSTALL_KEYS)

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from enum import Enum
 import sys
 
 import boto3
@@ -53,6 +54,18 @@ RUNTIME_CONFIG = {
         "LambdaExtension": True,
     },
 }
+
+
+class DefaultStackNames(Enum):
+    """Possible Default Stack Names depending on how log-ingestion function may exist in ecosystem
+
+    Args:
+        Enum ([type]): names of CloudFormation Stacks, based around
+        how the log-ingestion function might exist in one's AWS ecosystem
+    """
+
+    SERVERLESS_INSTALLED_FUNC_STACK = "serverlessrepo-NewRelic-log-ingestion"
+    CLI_TOOL_BASED_INSTALLED_FUNC_STACK = "NewRelic-log-ingestion"
 
 
 def catch_boto_errors(func):


### PR DESCRIPTION
WIP!

need to compare it to the 'most-recent' possible one, but tentatively can be done scraping cloudformation stacks if they've managed to installed it through somewhat default means but idk
/shrug-shrug
![Screen Shot 2022-01-22 at 7 39 28 PM](https://user-images.githubusercontent.com/5370752/150663851-74022fc9-5c8d-493d-93d3-ba88a2e43bf8.png)
..thinking something like that...
then like we just say "oh hey you're on x version, latest is a.b.c, we suggest upgrading, link to how to do that here: ___"
but idk

Not fully implemented, needs more work, drafting PR for now...

when you don't have anything better to do on a Saturday because covid so you try to pump out some features to open source...I guess 😆 
