### PR TITLE
GQL New Version Is Breaking Fresh CLI Tool Installs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3
 click
 colorama
-gql
+gql==2.0.0
 requests
 tabulate

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "click>=7.1.2",
         "colorama",
         "emoji",
-        "gql",
+        "gql==2.0.0",
         "requests",
         "tabulate",
     ],


### PR DESCRIPTION
Pinning the dependency to version 2.0.0 fixes this.

3.0.0 was released January 22nd.
https://pypi.org/project/gql/#history

This CLI Tool has been broken since then for those that are installing it fresh.
