### PR TITLE
doc: Adjust Failure Message to Warning

### DIFF
--- a/newrelic_lambda_cli/integrations.py
+++ b/newrelic_lambda_cli/integrations.py
@@ -525,10 +525,11 @@ def install_log_ingestion(
                 failure("Failed to create 'newrelic-log-ingestion' function: %s" % e)
                 return False
         else:
-            failure(
+            warning(
                 "CloudFormation Stack NewRelicLogIngestion exists (status: %s), but "
                 "newrelic-log-ingestion Lambda function does not.\n"
-                "Please manually delete the stack and re-run this command."
+                "IF you wish to use the New Relic Lambda Extension you can ignore this.\n"
+                "Otherwise please manually delete the stack and re-run this command."
                 % stack_status
             )
             return False


### PR DESCRIPTION
* newrelic-log-ingestion function is not required
* reframe the failure message as a warning

Resolves: doc/adj-failure-to-warning

See Screenshot:
<img width="1575" alt="Screen Shot 2022-02-06 at 8 30 25 PM" src="https://user-images.githubusercontent.com/5370752/152725030-d9cb254f-76b3-40f6-9e9d-954b457d03fe.png">

