### PR TITLE
Fix error handling in link_account

### DIFF
--- a/newrelic_lambda_cli/api.py
+++ b/newrelic_lambda_cli/api.py
@@ -156,10 +156,10 @@ class NewRelicGQL(object):
         try:
             return res["cloudLinkAccount"]["linkedAccounts"][0]
         except (IndexError, KeyError):
-            if "errors" in res:
+            if "errors" in res["cloudLinkAccount"]:
                 failure(
                     "Error while linking account with New Relic:\n%s"
-                    % "\n".join([e["message"] for e in res["errors"] if "message" in e])
+                    % "\n".join([e["message"] for e in res["cloudLinkAccount"]["errors"] if "message" in e])
                 )
             return None
 

--- a/tests/test_new_relic_gql.py
+++ b/tests/test_new_relic_gql.py
@@ -1,0 +1,19 @@
+from unittest.mock import Mock, MagicMock, patch
+
+from newrelic_lambda_cli.api import NewRelicGQL
+
+@patch('newrelic_lambda_cli.api.failure')
+def test_link_account_with_errors(failure):
+    mock_gql = NewRelicGQL("123456789", "foobar")
+    mock_gql.query = Mock(
+        return_value={
+            "cloudLinkAccount": {
+                "errors": [{ "message": "Foo Bar" }]
+            }
+        }
+    )
+
+    account = mock_gql.link_account("role_arn", "account_name")
+
+    failure.assert_called_once_with("Error while linking account with New Relic:\nFoo Bar")
+    assert account == None


### PR DESCRIPTION
The error handling in `link_account` method is swallowing real error message, which makes it hard to debug.

this PR tries to address that and also adding a test for it, please kindly review