### PR TITLE
Fix: Replace deprecated emoji param

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,7 @@ coverage==5.3
 cryptography==3.3.2
 docker==4.3.1
 docutils==0.15.2
-emoji==0.5.4
+emoji==2.0.0
 gql==2.0.0
 graphql-core==2.3.2
 idna==2.10

--- a/newrelic_lambda_cli/cliutils.py
+++ b/newrelic_lambda_cli/cliutils.py
@@ -8,13 +8,13 @@ from click.exceptions import Exit
 
 def done(message):
     """Prints a done message to the terminal"""
-    click.echo(emoji.emojize(":sparkles: %s :sparkles:" % message, use_aliases=True))
+    click.echo(emoji.emojize(":sparkles: %s :sparkles:" % message, language='alias'))
 
 
 def failure(message, exit=False):
     """Prints a failure message to the terminal"""
     click.echo(
-        emoji.emojize(":heavy_multiplication_x: %s" % message, use_aliases=True),
+        emoji.emojize(":heavy_multiplication_x: %s" % message, language='alias'),
         color="red",
         err=True,
     )
@@ -25,7 +25,7 @@ def failure(message, exit=False):
 def success(message):
     """Prints a success message to the terminal"""
     click.echo(
-        emoji.emojize(":heavy_check_mark: %s" % message, use_aliases=True),
+        emoji.emojize(":heavy_check_mark: %s" % message, language='alias'),
         color="green",
     )
 
@@ -33,6 +33,6 @@ def success(message):
 def warning(message):
     """Prints a warningmessage to the terminal"""
     click.echo(
-        emoji.emojize(":heavy_exclamation_mark: %s" % message, use_aliases=True),
+        emoji.emojize(":heavy_exclamation_mark: %s" % message, language='alias'),
         color="blue",
     )

--- a/newrelic_lambda_cli/cliutils.py
+++ b/newrelic_lambda_cli/cliutils.py
@@ -8,13 +8,13 @@ from click.exceptions import Exit
 
 def done(message):
     """Prints a done message to the terminal"""
-    click.echo(emoji.emojize(":sparkles: %s :sparkles:" % message, language='alias'))
+    click.echo(emoji.emojize(":sparkles: %s :sparkles:" % message, language="alias"))
 
 
 def failure(message, exit=False):
     """Prints a failure message to the terminal"""
     click.echo(
-        emoji.emojize(":heavy_multiplication_x: %s" % message, language='alias'),
+        emoji.emojize(":heavy_multiplication_x: %s" % message, language="alias"),
         color="red",
         err=True,
     )
@@ -25,7 +25,7 @@ def failure(message, exit=False):
 def success(message):
     """Prints a success message to the terminal"""
     click.echo(
-        emoji.emojize(":heavy_check_mark: %s" % message, language='alias'),
+        emoji.emojize(":heavy_check_mark: %s" % message, language="alias"),
         color="green",
     )
 
@@ -33,6 +33,6 @@ def success(message):
 def warning(message):
     """Prints a warningmessage to the terminal"""
     click.echo(
-        emoji.emojize(":heavy_exclamation_mark: %s" % message, language='alias'),
+        emoji.emojize(":heavy_exclamation_mark: %s" % message, language="alias"),
         color="blue",
     )


### PR DESCRIPTION
Fixes a bug caused by [a recent major release of emoji](https://github.com/carpedm20/emoji/releases/tag/v2.0.0) which deprecated the `use_aliases` param. This also bumps emoji to `2.0.0` in `dev-requirements.txt`

Stacktrace for reference:
```python
│Traceback (most recent call last):
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/bin/newrelic-lambda", line 10, in <module>
│    sys.exit(main())
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/newrelic_lambda_cli/cli/__init__.py", line 25, in main
│    cli()
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
│    return self.main(*args, **kwargs)
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/click/core.py", line 1055, in main
│    rv = self.invoke(ctx)
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
│    return _process_result(sub_ctx.command.invoke(sub_ctx))
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
│    return _process_result(sub_ctx.command.invoke(sub_ctx))
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
│    return ctx.invoke(self.callback, **ctx.params)
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/click/core.py", line 760, in invoke
│    return __callback(*args, **kwargs)
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
│    return f(get_current_context(), *args, **kwargs)
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/newrelic_lambda_cli/cli/integrations.py", line 134, in install
│    role = integrations.create_integration_role(input)
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/newrelic_lambda_cli/utils.py", line 61, in _boto_error_wrapper
│    return func(*args, **kwargs)
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/newrelic_lambda_cli/integrations.py", line 460, in create_integration_role
│    success("New Relic AWS Lambda integration role '%s' already exists" % role_name)
│  File "/home/runner/work/data-science-search/data-science-search/infrastructure/dev/newrelic/.terragrunt-cache/A_NXIAFRkBI6_uAOrRDMQqcYrFw/FdGlD4oqaMFCY3ymUwnTIcFC9fk/newrelic/venv/lib/python3.8/site-packages/newrelic_lambda_cli/cliutils.py", line 28, in success
│    emoji.emojize(":heavy_check_mark: %s" % message, use_aliases=True),
│TypeError: emojize() got an unexpected keyword argument 'use_aliases'
```