### PR TITLE
chore: Added note on support up through Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ manual function wrapping is required using the runtime specific New Relic agent.
 
 ## Requirements
 
-* Python >= 3.3
+* Python >= 3.3 < 3.10
 * Retrieve your [New relic Account ID](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id) and [User API Key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
 
 ## Recommendations


### PR DESCRIPTION
One user reports difficulty using the CLI with Python 3.10 installed on their development machine, but no such trouble when they downgrade to Python 3.9. This adds a note about that. 

Signed-off-by: mrickard <maurice@mauricerickard.com>