### PR TITLE
Pin black to v22.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
           name: Check code style
           command: |
             sudo pip install -q -U pip
+            sudo pip install -q -U packaging==20.4
             sudo pip install -q -U black
             black --check newrelic_lambda_cli tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
       - run:
           name: Check code style
           command: |
-            sudo pip install -q -U pip 'packaging<20.5'
-            sudo pip install -q -U black
+            sudo pip install -q -U pip
+            sudo pip install -q -U 'black<22.10.1'
             black --check newrelic_lambda_cli tests
       - run:
           name: Check README

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,7 @@ jobs:
       - run:
           name: Check code style
           command: |
-            sudo pip install -q -U pip
-            sudo pip install -q -U packaging==20.4
+            sudo pip install -q -U pip 'packaging<20.5'
             sudo pip install -q -U black
             black --check newrelic_lambda_cli tests
       - run:

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,3 @@ setup(
     include_package_data=True,
     zip_safe=False,
 )
-

--- a/setup.py
+++ b/setup.py
@@ -32,3 +32,4 @@ setup(
     include_package_data=True,
     zip_safe=False,
 )
+


### PR DESCRIPTION
This PR updates the .circleci/config.yml file to pin black to version 22.10.0 so that the packaging library's version is compatible with the version of poetry