### PR TITLE
feat: adds Python 3.10 to the supported runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * python3.7
 * python3.8
 * python3.9
+* python3.10
 
 **Note:** Automatic handler wrapping is only supported for Node.js and Python. For other runtimes,
 manual function wrapping is required using the runtime specific New Relic agent.

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -52,6 +52,10 @@ RUNTIME_CONFIG = {
         "Handler": "newrelic_lambda_wrapper.handler",
         "LambdaExtension": True,
     },
+    "python3.10": {
+        "Handler": "newrelic_lambda_wrapper.handler",
+        "LambdaExtension": True,
+    },
 }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,6 +88,7 @@ def test_supports_lambda_extension():
             "python3.7",
             "python3.8",
             "python3.9",
+            "python3.10",
         )
     )
     assert not any(


### PR DESCRIPTION
There's already New Relic AWS Lambda Layer Python 3.10 available - https://layers.newrelic-external.com/
however when installing the layer via:
```
newrelic-lambda layers install --layer-arn "arn:aws:lambda:us-east-1:451483290750:layer:NewRelicPython310:6"
```
one is getting `Unsupported Lambda runtime for 'arn:aws:lambda:us-east-1:***:function:name-of-lambda-fn': python3.10`

Not sure if it's all that's needed for it to start working.