### PR TITLE
feat: adds Python 3.11 to the supported runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * python3.8
 * python3.9
 * python3.10
+* python3.11
 
 **Note:** Automatic handler wrapping is only supported for Node.js, Python and Java. For other runtimes,
 manual function wrapping is required using the runtime specific New Relic agent.

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -60,6 +60,10 @@ RUNTIME_CONFIG = {
         "Handler": "newrelic_lambda_wrapper.handler",
         "LambdaExtension": True,
     },
+    "python3.11": {
+        "Handler": "newrelic_lambda_wrapper.handler",
+        "LambdaExtension": True,
+    },
 }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,6 +90,7 @@ def test_supports_lambda_extension():
             "python3.8",
             "python3.9",
             "python3.10",
+            "python3.11",
         )
     )
     assert not any(


### PR DESCRIPTION
There's already New Relic AWS Lambda Layer Python 3.11 available - https://layers.newrelic-external.com/
however when installing the layer via:

newrelic-lambda layers install --layer-arn "arn:aws:lambda:ap-southeast-2:451483290750:layer:NewRelicPython311:4"
one is getting Unsupported Lambda runtime for 'arn:aws:lambda:ap-southeast-2:***:function:name-of-lambda-fn': python3.11


Based on previous work such as https://github.com/newrelic/newrelic-lambda-cli/pull/241