### PR TITLE
Use Python 3.9, including for ingestion lambdas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   test:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.9
     steps:
       - checkout
       - run:
@@ -17,7 +17,7 @@ jobs:
 
   code-style:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.9
     steps:
       - checkout
       - run:
@@ -35,7 +35,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.9
     steps:
       - checkout
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.9-slim
 RUN useradd -r -u 1000 newrelic-lambda-cli
 USER newrelic-lambda-cli
 WORKDIR /home/newrelic-lambda-cli

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
 coverage==5.3
-cryptography==3.3.2
+cryptography==41.0.4
 docker==4.3.1
 docutils==0.15.2
 emoji==2.0.0
@@ -39,7 +39,7 @@ pytest-cov==2.10.1
 pytest-runner==5.2
 python-dateutil==2.8.1
 pytz==2020.1
-PyYAML==5.4
+PyYAML==6.0.1
 regex==2020.10.15
 requests==2.24.0
 responses==0.12.0
@@ -48,7 +48,7 @@ s3transfer==0.3.3
 six==1.15.0
 tabulate==0.8.7
 toml==0.10.1
-typed-ast==1.4.1
+typed-ast==1.5.5
 typing-extensions==3.7.4.3
 urllib3==1.25.10
 websocket-client==0.57.0

--- a/newrelic_lambda_cli/templates/import-template.yaml
+++ b/newrelic_lambda_cli/templates/import-template.yaml
@@ -65,7 +65,7 @@ Resources:
       FunctionName: newrelic-log-ingestion
       MemorySize:
         Ref: MemorySize
-      Runtime: python3.7
+      Runtime: python3.9
       Role: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${FunctionRole}
       Timeout:
         Ref: Timeout
@@ -87,7 +87,7 @@ Resources:
       FunctionName: newrelic-log-ingestion
       MemorySize:
         Ref: MemorySize
-      Runtime: python3.7
+      Runtime: python3.9
       Timeout:
         Ref: Timeout
       Environment:


### PR DESCRIPTION
This fixes #248 by upgrading the Python version from 3.7 to 3.9. 3.7 is going out of support soon (end of November), so this has to happen.

This also requires upgrading a few dev dependencies to newer versions that provide pre-built wheels for 3.9 for my machine. I only upgraded the ones don't build by default on my computer (ARM macOS, with various packages/compilers installed), there are likely others that _should_ be upgraded.

I tried upgrading to even newer versions but these failed to run `pytest` (presumably it and/or other libs need to be upgraded too), plus, it seems the latest version of https://github.com/newrelic/aws-log-ingestion only supports 3.9.

<details><summary>Error on 3.10</summary>

```
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.10/3.10.10_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/homebrew/Cellar/python@3.10/3.10.10_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/pytest/__main__.py", line 7, in <module>
    raise SystemExit(pytest.console_main())
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/_pytest/config/__init__.py", line 180, in console_main
    code = main()
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/_pytest/config/__init__.py", line 136, in main
    config = _prepareconfig(args, plugins)
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/_pytest/config/__init__.py", line 313, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/pluggy/manager.py", line 84, in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/pluggy/callers.py", line 203, in _multicall
    gen.send(outcome)
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/_pytest/helpconfig.py", line 99, in pytest_cmdline_parse
    config = outcome.get_result()  # type: Config
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/_pytest/config/__init__.py", line 932, in pytest_cmdline_parse
    self.parse(args)
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1204, in parse
    self._preparse(args, addopts=addopts)
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1097, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/pluggy/manager.py", line 299, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/opt/homebrew/Cellar/python@3.10/3.10.10_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/opt/homebrew/Cellar/python@3.10/3.10.10_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 161, in exec_module
    source_stat, co = _rewrite_test(fn, self.config)
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv310/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 360, in _rewrite_test
    co = compile(tree, fn_, "exec", dont_inherit=True)
TypeError: required field "lineno" missing from alias
```

</details>
<details><summary>Error on 3.11</summary>

```
Traceback (most recent call last):
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv/lib/python3.11/site-packages/py/_vendored_packages/apipkg.py", line 141, in __makeattr
    modpath, attrname = self.__map__[name]
                        ~~~~~~~~~~~~^^^^^^
KeyError: '__spec__'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 112, in _get_module_details
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv/lib/python3.11/site-packages/pytest/__init__.py", line 7, in <module>
    from _pytest.assertion import register_assert_rewrite
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv/lib/python3.11/site-packages/_pytest/assertion/__init__.py", line 10, in <module>
    from _pytest.assertion import rewrite
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv/lib/python3.11/site-packages/_pytest/assertion/rewrite.py", line 30, in <module>
    from _pytest.assertion import util
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv/lib/python3.11/site-packages/_pytest/assertion/util.py", line 14, in <module>
    import _pytest._code
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv/lib/python3.11/site-packages/_pytest/_code/__init__.py", line 2, in <module>
    from .code import Code
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv/lib/python3.11/site-packages/_pytest/_code/code.py", line 53, in <module>
    class Code:
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv/lib/python3.11/site-packages/_pytest/_code/code.py", line 73, in Code
    def path(self) -> Union[py.path.local, str]:
                            ^^^^^^^^^^^^^
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv/lib/python3.11/site-packages/py/_vendored_packages/apipkg.py", line 148, in __makeattr
    result = importobj(modpath, attrname)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv/lib/python3.11/site-packages/py/_vendored_packages/apipkg.py", line 69, in importobj
    module = __import__(modpath, None, None, ['__doc__'])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1136, in _find_and_load_unlocked
  File "/Users/huon/projects/newrelic/newrelic-lambda-cli/.venv/lib/python3.11/site-packages/py/_vendored_packages/apipkg.py", line 146, in __makeattr
    raise AttributeError(name)
AttributeError: __spec__
```

</details>

I'm not sure how to test accurately, and wonder if further changes may be required.