### PR TITLE
Fix .pre-commit-config.yaml format and multithreading errors for Boto3 Session

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
--   repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black
     rev: stable
     hooks:
-    - id: black
-      language_version: python3
+      - id: black
+        language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+---
+repos:
 -   repo: https://github.com/psf/black
     rev: stable
     hooks:

--- a/newrelic_lambda_cli/cli/layers.py
+++ b/newrelic_lambda_cli/cli/layers.py
@@ -108,12 +108,6 @@ def install(ctx, **kwargs):
     """Install New Relic AWS Lambda Layers"""
     input = LayerInstall(session=None, verbose=ctx.obj["VERBOSE"], **kwargs)
 
-    input = input._replace(
-        session=boto3.Session(
-            profile_name=input.aws_profile, region_name=input.aws_region
-        )
-    )
-
     if input.aws_permissions_check:
         permissions.ensure_layer_install_permissions(input)
 
@@ -121,7 +115,16 @@ def install(ctx, **kwargs):
 
     with ThreadPoolExecutor() as executor:
         futures = [
-            executor.submit(layers.install, input, function) for function in functions
+            executor.submit(
+                layers.install,
+                input._replace(
+                    session=boto3.Session(
+                        profile_name=input.aws_profile, region_name=input.aws_region
+                    )
+                ),
+                function,
+            )
+            for function in functions
         ]
         install_success = all(future.result() for future in as_completed(futures))
 
@@ -179,12 +182,6 @@ def uninstall(ctx, **kwargs):
     """Uninstall New Relic AWS Lambda Layers"""
     input = LayerUninstall(session=None, verbose=ctx.obj["VERBOSE"], **kwargs)
 
-    input = input._replace(
-        session=boto3.Session(
-            profile_name=input.aws_profile, region_name=input.aws_region
-        )
-    )
-
     if input.aws_permissions_check:
         permissions.ensure_layer_uninstall_permissions(input)
 
@@ -192,7 +189,16 @@ def uninstall(ctx, **kwargs):
 
     with ThreadPoolExecutor() as executor:
         futures = [
-            executor.submit(layers.uninstall, input, function) for function in functions
+            executor.submit(
+                layers.uninstall,
+                input._replace(
+                    session=boto3.Session(
+                        profile_name=input.aws_profile, region_name=input.aws_region
+                    )
+                ),
+                function,
+            )
+            for function in functions
         ]
         uninstall_success = all(future.result() for future in as_completed(futures))
 

--- a/newrelic_lambda_cli/cli/subscriptions.py
+++ b/newrelic_lambda_cli/cli/subscriptions.py
@@ -57,12 +57,6 @@ def install(**kwargs):
     """Install New Relic AWS Lambda Log Subscriptions"""
     input = SubscriptionInstall(session=None, **kwargs)
 
-    input = input._replace(
-        session=boto3.Session(
-            profile_name=input.aws_profile, region_name=input.aws_region
-        )
-    )
-
     if input.aws_permissions_check:
         permissions.ensure_subscription_install_permissions(input)
 
@@ -70,7 +64,15 @@ def install(**kwargs):
 
     with ThreadPoolExecutor() as executor:
         futures = [
-            executor.submit(subscriptions.create_log_subscription, input, function)
+            executor.submit(
+                subscriptions.create_log_subscription,
+                input._replace(
+                    session=boto3.Session(
+                        profile_name=input.aws_profile, region_name=input.aws_region
+                    )
+                ),
+                function,
+            )
             for function in functions
         ]
         install_success = all(future.result() for future in as_completed(futures))
@@ -104,12 +106,6 @@ def uninstall(**kwargs):
     """Uninstall New Relic AWS Lambda Log Subscriptions"""
     input = SubscriptionUninstall(session=None, **kwargs)
 
-    input = input._replace(
-        session=boto3.Session(
-            profile_name=input.aws_profile, region_name=input.aws_region
-        )
-    )
-
     if input.aws_permissions_check:
         permissions.ensure_subscription_uninstall_permissions(input)
 
@@ -117,7 +113,15 @@ def uninstall(**kwargs):
 
     with ThreadPoolExecutor() as executor:
         futures = [
-            executor.submit(subscriptions.remove_log_subscription, input, function)
+            executor.submit(
+                subscriptions.remove_log_subscription,
+                input._replace(
+                    session=boto3.Session(
+                        profile_name=input.aws_profile, region_name=input.aws_region
+                    )
+                ),
+                function,
+            )
             for function in functions
         ]
         uninstall_success = all(future.result() for future in as_completed(futures))


### PR DESCRIPTION
# Description
- Modified .pre-commit-config.yaml because the following error occurred when trying to commit with pre-commit enabled. c281208
```
An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml
=====> Expected a Config map but got a list
```

- Boto3 Session object is not thread-safe, so specifying multiple `--function` options causes the following errors.
So I changed to create a new Boto3 Session object for each thread. e7e02c0
```
Traceback (most recent call last):
  File "/opt/homebrew/bin/newrelic-lambda", line 8, in <module>
    sys.exit(main())
             ^^^^^^
...
  File "/opt/homebrew/lib/python3.11/site-packages/newrelic_lambda_cli/layers.py", line 212, in install
    client = input.session.client("lambda")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/boto3/session.py", line 299, in client
    return self._session.create_client(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/botocore/session.py", line 957, in create_client
    credentials = self.get_credentials()
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/botocore/session.py", line 513, in get_credentials
    self._credentials = self._components.get_component(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/botocore/session.py", line 1144, in get_component
    del self._deferred[name]
        ~~~~~~~~~~~~~~^^^^^^
KeyError: 'credential_provider'
```

# References
- https://boto3.amazonaws.com/v1/documentation/api/1.14.31/guide/session.html#multithreading-or-multiprocessing-with-sessions