### PR TITLE
Add support for newrelic-log-ingestion-xxx name

### DIFF
--- a/newrelic_lambda_cli/cli/integrations.py
+++ b/newrelic_lambda_cli/cli/integrations.py
@@ -73,6 +73,13 @@ def register(group):
     show_default=False,
 )
 @click.option(
+    "--log-ingestion-lambda",
+    default="newrelic-log-ingestion",
+    help="The name of the log ingestion lambda function",
+    metavar="<lambda_name>",
+    show_default=False,
+)
+@click.option(
     "--enable-license-key-secret/--disable-license-key-secret",
     default=True,
     show_default=True,

--- a/newrelic_lambda_cli/cli/subscriptions.py
+++ b/newrelic_lambda_cli/cli/subscriptions.py
@@ -46,6 +46,13 @@ def register(group):
     multiple=True,
 )
 @click.option(
+    "--log-ingestion-lambda",
+    default="newrelic-log-ingestion",
+    help="The name of the log ingestion lambda function",
+    metavar="<lambda_name>",
+    show_default=False,
+)
+@click.option(
     "filter_pattern",
     "--filter-pattern",
     default=DEFAULT_FILTER_PATTERN,

--- a/newrelic_lambda_cli/integrations.py
+++ b/newrelic_lambda_cli/integrations.py
@@ -324,7 +324,6 @@ def update_log_ingestion_function(input):
         len(stack_resources) > 0
         and stack_resources[0]["ResourceType"] == "AWS::CloudFormation::Stack"
     ):
-
         click.echo("Unwrapping nested stack... ", nl=False)
 
         # Set the ingest function itself to disallow deletes
@@ -517,13 +516,13 @@ def install_log_ingestion(
     Returns True for success and False for failure.
     """
     assert isinstance(input, IntegrationInstall)
-    function = get_function(input.session, "newrelic-log-ingestion")
+    function = get_function(input.session, input.log_ingestion_lambda)
     if function is None:
         stack_status = _check_for_ingest_stack(input.session)
         if stack_status is None:
             click.echo(
-                "Setting up 'newrelic-log-ingestion' function in region: %s"
-                % input.session.region_name
+                "Setting up %s function in region: %s"
+                % (input.log_ingestion_lambda, input.session.region_name)
             )
             try:
                 _create_log_ingestion_function(
@@ -543,8 +542,8 @@ def install_log_ingestion(
             return False
     else:
         success(
-            "The 'newrelic-log-ingestion' function already exists in region %s, "
-            "skipping" % input.session.region_name
+            "The %s function already exists in region %s, "
+            "skipping" % (input.log_ingestion_lambda, input.session.region_name)
         )
     return True
 

--- a/newrelic_lambda_cli/subscriptions.py
+++ b/newrelic_lambda_cli/subscriptions.py
@@ -83,11 +83,11 @@ def _remove_subscription_filter(session, function_name, filter_name):
 @catch_boto_errors
 def create_log_subscription(input, function_name):
     assert isinstance(input, SubscriptionInstall)
-    destination = get_function(input.session, "newrelic-log-ingestion")
+    destination = get_function(input.session, input.log_ingestion_lambda)
     if destination is None:
         failure(
-            "Could not find 'newrelic-log-ingestion' function. Is the New Relic AWS "
-            "integration installed?"
+            "Could not find %s function. Is the New Relic AWS "
+            "integration installed?" % input.log_ingestion_lambda
         )
         return False
     destination_arn = destination["Configuration"]["FunctionArn"]

--- a/newrelic_lambda_cli/types.py
+++ b/newrelic_lambda_cli/types.py
@@ -15,6 +15,7 @@ INTEGRATION_INSTALL_KEYS = [
     "nr_region",
     "timeout",
     "role_name",
+    "log_ingestion_lambda",
     "enable_license_key_secret",
     "enable_cw_ingest",
     "integration_arn",
@@ -81,6 +82,7 @@ SUBSCRIPTION_INSTALL_KEYS = [
     "aws_permissions_check",
     "functions",
     "excludes",
+    "log_ingestion_lambda",
     "filter_pattern",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md"), "r").read()
 
 setup(
     name="newrelic-lambda-cli",
-    version="0.7.6",
+    version="0.7.7",
     python_requires=">=3.3",
     description="A CLI to install the New Relic AWS Lambda integration and layers.",
     long_description=README,

--- a/tests/cli/test_subscriptions.py
+++ b/tests/cli/test_subscriptions.py
@@ -10,6 +10,7 @@ def test_subscriptions_install(aws_credentials, cli_runner):
     Assert that 'newrelic-lambda subscriptions install' attempts to install the
     New Relic log subscription on a function.
     """
+    log_ingestion_lambda_name = "newrelic-log-ingestion-12f9323e1d13"
     register_groups(cli)
 
     result = cli_runner.invoke(
@@ -22,6 +23,8 @@ def test_subscriptions_install(aws_credentials, cli_runner):
             "foobar",
             "--aws-region",
             "us-east-1",
+            "--log-ingestion-lambda",
+            log_ingestion_lambda_name,
         ],
         env={
             "AWS_ACCESS_KEY_ID": "testing",
@@ -34,7 +37,7 @@ def test_subscriptions_install(aws_credentials, cli_runner):
     assert result.exit_code == 1
     assert result.stdout == ""
     assert (
-        "Could not find 'newrelic-log-ingestion' function. "
+        f"Could not find {log_ingestion_lambda_name} function. "
         "Is the New Relic AWS integration installed?"
     ) in result.stderr
 
@@ -50,6 +53,8 @@ def test_subscriptions_install(aws_credentials, cli_runner):
             "barbaz",
             "--aws-region",
             "us-east-1",
+            "--log-ingestion-lambda",
+            log_ingestion_lambda_name,
         ],
         env={
             "AWS_ACCESS_KEY_ID": "testing",
@@ -62,7 +67,7 @@ def test_subscriptions_install(aws_credentials, cli_runner):
     assert result2.exit_code == 1
     assert result2.stdout == ""
     assert (
-        "Could not find 'newrelic-log-ingestion' function. "
+        f"Could not find {log_ingestion_lambda_name} function. "
         "Is the New Relic AWS integration installed?"
     ) in result2.stderr
 

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -42,8 +42,8 @@ def test_create_log_subscription(
     mock_create_subscription_filter.return_value = True
     mock_remove_subscription_filter.return_value = True
 
-    assert create_log_subscription(subscription_install(), "FooBarBaz") is False
-    mock_get_function.assert_called_once_with(None, "newrelic-log-ingestion")
+    assert create_log_subscription(subscription_install(log_ingestion_lambda="newrelic-log-ingestion-12f9323e1d13"), "FooBarBaz") is False
+    mock_get_function.assert_called_once_with(None, "newrelic-log-ingestion-12f9323e1d13")
     mock_get_subscription_filters.assert_not_called()
 
     assert create_log_subscription(subscription_install(), "FooBarBaz") is False


### PR DESCRIPTION
Adds support for newrelic-log-ingestion-<stack id> name to maintain compatibility with https://github.com/newrelic/aws-log-ingestion/pull/88. Use new name in templates and new installations and fallback to old name when updating, deleting, etc.

This fixes https://github.com/newrelic/newrelic-lambda-cli/issues/240.