### PR TITLE
Add support for newrelic-log-ingestion-xxxx name

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ newrelic-lambda integrations install \
 | `--aws-role-policy` | No | Specify an alternative IAM role policy ARN for this integration. |
 | `--disable-license-key-secret` | No | Don't create a managed secret for your account's New Relic License Key |
 | `--tag <key> <value>` | No | Sets tags on the CloudFormation Stacks this CLI creates. Can be used multiple times, example: `--tag key1 value1 --tag key2 value2`. |
+| `--stackname` | No | The AWS Cloudformation stack name which contains the newrelic-log-ingestion lambda function. If no value is provided, the command searches for the NewRelicLogIngestion stack |
 
 #### Uninstall Integration
 
@@ -127,6 +128,7 @@ newrelic-lambda integrations uninstall
 | `--aws-region` or `-r` | No | The AWS region for the integration. Can use `AWS_DEFAULT_REGION` environment variable. Defaults to AWS session region. |
 | `--force` or `-f` | No | Forces uninstall non-interactively |
 | `--nr-account-id` or `-a` | No | The [New Relic Account ID](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id) for the integration. Only required if also uninstalling the New Relic AWS Lambda integration. Can also use the `NEW_RELIC_ACCOUNT_ID` environment variable. |
+| `--stackname` | No | The AWS Cloudformation stack name which contains the newrelic-log-ingestion lambda function. If no value is provided, the command searches for the NewRelicLogIngestion stack |
 
 #### Update Integration
 
@@ -154,6 +156,7 @@ newrelic-lambda integrations update \
 | `--aws-region` or `-r` | No | The AWS region for the integration. Can use `AWS_DEFAULT_REGION` environment variable. Defaults to AWS session region. |
 | `--disable-license-key-secret` | No | Disable automatic creation of the license key secret on update. The secret is not created if it exists. |
 | `--tag <key> <value>` | No | Sets tags on the CloudFormation Stacks this CLI creates. Can be used multiple times, example: `--tag key1 value1 --tag key2 value2`. |
+| `--stackname` | No | The AWS Cloudformation stack name which contains the newrelic-log-ingestion lambda function. If no value is provided, the command searches for the NewRelicLogIngestion stack |
 
 ### AWS Lambda Layers
 
@@ -226,6 +229,7 @@ newrelic-lambda subscriptions install --function <name or arn>
 | Option | Required? | Description |
 |--------|-----------|-------------|
 | `--function` or `-f` | Yes | The AWS Lambda function name or ARN in which to add a log subscription. Can provide multiple `--function` arguments. Will also accept `all`, `installed` and `not-installed` similar to `newrelic-lambda functions list`. |
+| `--stackname` | No | The AWS Cloudformation stack name which contains the newrelic-log-ingestion lambda function. If no value is provided, the command searches for the NewRelicLogIngestion stack |
 | `--exclude` or `-e` | No | A function name to exclude while installing subscriptions. Can provide multiple `--exclude` arguments. Only checked when `all`, `installed` and `not-installed` are used. See `newrelic-lambda functions list` for function names. |
 | `--filter-pattern` | No | Specify a custom log subscription filter pattern. To collect all logs use `--filter-pattern ""`. |
 | `--aws-profile` or `-p` | No | The AWS profile to use for this command. Can also use `AWS_PROFILE`. Will also check `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables if not using AWS CLI. |
@@ -240,6 +244,7 @@ newrelic-lambda subscriptions uninstall --function <name or arn>
 | Option | Required? | Description |
 |--------|-----------|-------------|
 | `--function` or `-f` | Yes | The AWS Lambda function name or ARN in which to remove a log subscription. Can provide multiple `--function` arguments. Will also accept `all`, `installed` and `not-installed` similar to `newrelic-lambda functions list`. |
+| `--stackname` | No | The AWS Cloudformation stack name which contains the newrelic-log-ingestion lambda function. If no value is provided, the command searches for the NewRelicLogIngestion stack |
 | `--exclude` or `-e` | No | A function name to exclude while uninstalling subscriptions. Can provide multiple `--exclude` arguments. Only checked when `all`, `installed` and `not-installed` are used. See `newrelic-lambda functions list` for function names. |
 | `--aws-profile` or `-p` | No | The AWS profile to use for this command. Can also use `AWS_PROFILE`. Will also check `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables if not using AWS CLI. |
 | `--aws-region` or `-r` | No | The AWS region this function is located. Can use `AWS_DEFAULT_REGION` environment variable. Defaults to AWS session region. |

--- a/newrelic_lambda_cli/cli/__init__.py
+++ b/newrelic_lambda_cli/cli/__init__.py
@@ -6,6 +6,7 @@ from newrelic_lambda_cli.cli import functions, integrations, layers, subscriptio
 
 
 @click.group()
+@click.version_option()
 @click.option("--verbose", "-v", help="Increase verbosity", is_flag=True)
 @click.pass_context
 def cli(ctx, verbose):

--- a/newrelic_lambda_cli/cli/integrations.py
+++ b/newrelic_lambda_cli/cli/integrations.py
@@ -40,6 +40,14 @@ def register(group):
     is_flag=True,
 )
 @click.option(
+    "--stackname",
+    default="NewRelicLogIngestion",
+    help="The AWS Cloudformation stack name which contains the newrelic-log-ingestion lambda function",
+    metavar="<arn>",
+    show_default=False,
+    required=False,
+)
+@click.option(
     "--memory-size",
     "-m",
     default=128,
@@ -195,6 +203,14 @@ def install(ctx, **kwargs):
     required=False,
     type=click.INT,
 )
+@click.option(
+    "--stackname",
+    default="NewRelicLogIngestion",
+    help="The AWS Cloudformation stack name which contains the newrelic-log-ingestion lambda function",
+    metavar="<arn>",
+    show_default=False,
+    required=False,
+)
 @click.option("--force", "-f", help="Force uninstall non-interactively", is_flag=True)
 def uninstall(**kwargs):
     """Uninstall New Relic AWS Lambda Integration"""
@@ -251,6 +267,14 @@ def uninstall(**kwargs):
     help="Determines if logs are forwarded to New Relic Logging",
 )
 @click.option(
+    "--stackname",
+    default="NewRelicLogIngestion",
+    help="The AWS Cloudformation stack name which contains the newrelic-log-ingestion lambda function",
+    metavar="<arn>",
+    show_default=False,
+    required=False,
+)
+@click.option(
     "--memory-size",
     "-m",
     help="Memory size (in MiB) for the log ingestion function",
@@ -271,6 +295,14 @@ def uninstall(**kwargs):
     help="The name of a new pre-created execution role for the log ingest function",
     metavar="<role_name>",
     show_default=False,
+)
+@click.option(
+    "--stackname",
+    default="NewRelicLogIngestion",
+    help="The AWS Cloudformation stack name which contains the newrelic-log-ingestion lambda function",
+    metavar="<arn>",
+    show_default=False,
+    required=False,
 )
 @click.option(
     "--enable-license-key-secret/--disable-license-key-secret",

--- a/newrelic_lambda_cli/cli/subscriptions.py
+++ b/newrelic_lambda_cli/cli/subscriptions.py
@@ -38,6 +38,14 @@ def register(group):
     required=True,
 )
 @click.option(
+    "--stackname",
+    default="NewRelicLogIngestion",
+    help="The AWS Cloudformation stack name which contains the newrelic-log-ingestion lambda function",
+    metavar="<arn>",
+    show_default=False,
+    required=False,
+)
+@click.option(
     "excludes",
     "--exclude",
     "-e",
@@ -91,6 +99,14 @@ def install(**kwargs):
     metavar="<arn>",
     multiple=True,
     required=True,
+)
+@click.option(
+    "--stackname",
+    default="NewRelicLogIngestion",
+    help="The AWS Cloudformation stack name which contains the newrelic-log-ingestion lambda function",
+    metavar="<arn>",
+    show_default=False,
+    required=False,
 )
 @click.option(
     "excludes",

--- a/newrelic_lambda_cli/functions.py
+++ b/newrelic_lambda_cli/functions.py
@@ -70,8 +70,8 @@ def get_aliased_functions(input):
     functions = [
         function
         for function in input.functions
-        if function.lower()
-        not in ("all", "installed", "not-installed") and "newrelic-log-ingestion" not in function.lower()
+        if function.lower() not in ("all", "installed", "not-installed")
+        and "newrelic-log-ingestion" not in function.lower()
         and function not in input.excludes
     ]
 

--- a/newrelic_lambda_cli/functions.py
+++ b/newrelic_lambda_cli/functions.py
@@ -71,7 +71,7 @@ def get_aliased_functions(input):
         function
         for function in input.functions
         if function.lower()
-        not in ("all", "installed", "not-installed", "newrelic-log-ingestion")
+        not in ("all", "installed", "not-installed") and "newrelic-log-ingestion" not in function.lower()
         and function not in input.excludes
     ]
 

--- a/newrelic_lambda_cli/integrations.py
+++ b/newrelic_lambda_cli/integrations.py
@@ -43,8 +43,8 @@ def _get_role(session, role_name):
         raise click.UsageError(str(e))
 
 
-def _check_for_ingest_stack(session):
-    return _get_cf_stack_status(session, INGEST_STACK_NAME)
+def _check_for_ingest_stack(session, stack_name):
+    return _get_cf_stack_status(session, stack_name)
 
 
 def _get_cf_stack_status(session, stack_name, nr_account_id=None):
@@ -85,18 +85,19 @@ def _get_cf_stack_status(session, stack_name, nr_account_id=None):
     else:
         return res["Stacks"][0]["StackStatus"]
 
-def get_unique_newrelic_log_ingestion_name(session):
-    stack_id = _get_cf_stack_id(session, stack_name=INGEST_STACK_NAME)
-    return "newrelic-log-ingestion-%s"%(stack_id.split("/")[2].split("-")[4])
 
-def get_newrelic_log_ingestion_function(session):
-    unique_log_ingestion_name = get_unique_newrelic_log_ingestion_name(session)
-    old_log_ingestion_name = "newrelic-log-ingestion"
+def get_unique_newrelic_log_ingestion_name(session, stackname = None):
+    if not stackname:
+        stackname = INGEST_STACK_NAME
+    stack_id = _get_cf_stack_id(session, stack_name=stackname)
+    if stack_id:
+        return "newrelic-log-ingestion-%s"%(stack_id.split("/")[2].split("-")[4])
 
-    function = get_function(session, unique_log_ingestion_name)
-    if function is None:
-        function = get_function(session, old_log_ingestion_name)
-    return function
+def get_newrelic_log_ingestion_function(session, stackname = None):
+    unique_log_ingestion_name = get_unique_newrelic_log_ingestion_name(session, stackname)
+    if unique_log_ingestion_name:
+        function = get_function(session, unique_log_ingestion_name)
+        return function
 
 def _get_cf_stack_id(session, stack_name, nr_account_id=None):
     """Returns the StackId of the CloudFormation stack if it exists"""
@@ -135,6 +136,7 @@ def _get_cf_stack_id(session, stack_name, nr_account_id=None):
         raise click.UsageError(str(e))
     else:
         return res["Stacks"][0]["StackId"]
+
 
 # TODO: Merge this with create_integration_role?
 def _create_role(input):
@@ -250,31 +252,33 @@ def _import_log_ingestion_function(input, nr_license_key):
     )
 
     with open(template_path) as template:
-        unique_log_ingestion_name = get_unique_newrelic_log_ingestion_name(input.session)
-
-        change_set_name = "%s-IMPORT-%d" % (INGEST_STACK_NAME, int(time.time()))
-        click.echo("Creating change set: %s" % change_set_name)
-
-        change_set = client.create_change_set(
-            StackName=INGEST_STACK_NAME,
-            TemplateBody=template.read(),
-            Parameters=parameters,
-            Capabilities=capabilities,
-            Tags=[{"Key": key, "Value": value} for key, value in input.tags]
-            if input.tags
-            else [],
-            ChangeSetType="IMPORT",
-            ChangeSetName=change_set_name,
-            ResourcesToImport=[
-                {
-                    "ResourceType": "AWS::Lambda::Function",
-                    "LogicalResourceId": "NewRelicLogIngestionFunctionNoCap",
-                    "ResourceIdentifier": {"FunctionName": unique_log_ingestion_name},
-                }
-            ],
+        unique_log_ingestion_name = get_unique_newrelic_log_ingestion_name(
+            input.session
         )
+        if unique_log_ingestion_name:
+            change_set_name = "%s-IMPORT-%d" % (INGEST_STACK_NAME, int(time.time()))
+            click.echo("Creating change set: %s" % change_set_name)
 
-        _exec_change_set(client, change_set, "IMPORT")
+            change_set = client.create_change_set(
+                StackName=INGEST_STACK_NAME,
+                TemplateBody=template.read(),
+                Parameters=parameters,
+                Capabilities=capabilities,
+                Tags=[{"Key": key, "Value": value} for key, value in input.tags]
+                if input.tags
+                else [],
+                ChangeSetType="IMPORT",
+                ChangeSetName=change_set_name,
+                ResourcesToImport=[
+                    {
+                        "ResourceType": "AWS::Lambda::Function",
+                        "LogicalResourceId": "NewRelicLogIngestionFunctionNoCap",
+                        "ResourceIdentifier": {"FunctionName": unique_log_ingestion_name},
+                    }
+                ],
+            )
+
+            _exec_change_set(client, change_set, "IMPORT")
 
 
 def _create_log_ingestion_function(
@@ -293,11 +297,11 @@ def _create_log_ingestion_function(
     click.echo("Fetching new CloudFormation template url")
     template_url = _get_sar_template_url(input.session)
 
-    change_set_name = "%s-%s-%d" % (INGEST_STACK_NAME, mode, int(time.time()))
+    change_set_name = "%s-%s-%d" % (input.stackname, mode, int(time.time()))
     click.echo("Creating change set: %s" % change_set_name)
 
     change_set = client.create_change_set(
-        StackName=INGEST_STACK_NAME,
+        StackName=input.stackname,
         TemplateURL=template_url,
         Parameters=parameters,
         Capabilities=capabilities,
@@ -308,10 +312,10 @@ def _create_log_ingestion_function(
         ChangeSetName=change_set_name,
     )
 
-    _exec_change_set(client, change_set, mode)
+    _exec_change_set(client, change_set, mode, input.stackname)
 
 
-def _exec_change_set(client, change_set, mode, stack_name=INGEST_STACK_NAME):
+def _exec_change_set(client, change_set, mode, stack_name):
     click.echo(
         "Waiting for change set creation to complete, this may take a minute... ",
         nl=False,
@@ -376,7 +380,6 @@ def update_log_ingestion_function(input):
         len(stack_resources) > 0
         and stack_resources[0]["ResourceType"] == "AWS::CloudFormation::Stack"
     ):
-
         click.echo("Unwrapping nested stack... ", nl=False)
 
         # Set the ingest function itself to disallow deletes
@@ -394,10 +397,24 @@ def update_log_ingestion_function(input):
 
         # We can't change props during import, so let's set them to their current values
         lambda_client = input.session.client("lambda")
-        unique_log_ingestion_name = get_unique_newrelic_log_ingestion_name(input.session)
-        old_props = lambda_client.get_function_configuration(
-            FunctionName=unique_log_ingestion_name
+        unique_log_ingestion_name = get_unique_newrelic_log_ingestion_name(
+            input.session
         )
+        old_props = {}
+        try:
+            old_props = lambda_client.get_function_configuration(
+                FunctionName=unique_log_ingestion_name
+            )
+        except lambda_client.exceptions.ResourceNotFoundException:
+            old_props = lambda_client.get_function_configuration(
+                FunctionName="newrelic-log-ingestion"
+            )
+            warning(
+                "It looks like an old log ingestion function is present in this region. "
+                "Consider manually deleting this as it is no longer used and "
+                "has been replaced by a log ingestion function specific to the stack."
+            )
+
         old_role_name = old_props["Role"].split("/")[-1]
         old_nr_license_key = old_props["Environment"]["Variables"]["LICENSE_KEY"]
         old_enable_logs = False
@@ -477,19 +494,19 @@ def remove_log_ingestion_function(input):
     assert isinstance(input, IntegrationUninstall)
 
     client = input.session.client("cloudformation")
-    stack_status = _check_for_ingest_stack(input.session)
+    stack_status = _check_for_ingest_stack(input.session, input.stackname)
     if stack_status is None:
         click.echo(
             "No New Relic AWS Lambda log ingestion found in region %s, skipping"
             % input.session.region_name
         )
         return
-    click.echo("Deleting New Relic log ingestion stack '%s'" % INGEST_STACK_NAME)
-    client.delete_stack(StackName=INGEST_STACK_NAME)
+    click.echo("Deleting New Relic log ingestion stack '%s'" % input.stackname)
+    client.delete_stack(StackName=input.stackname)
     click.echo(
         "Waiting for stack deletion to complete, this may take a minute... ", nl=False
     )
-    client.get_waiter("stack_delete_complete").wait(StackName=INGEST_STACK_NAME)
+    client.get_waiter("stack_delete_complete").wait(StackName=input.stackname)
     success("Done")
 
 
@@ -570,23 +587,36 @@ def install_log_ingestion(
     Returns True for success and False for failure.
     """
     assert isinstance(input, IntegrationInstall)
-    function = get_newrelic_log_ingestion_function(input.session)
-    if function is None:
-        stack_status = _check_for_ingest_stack(input.session)
-        if stack_status is None:
-            click.echo(
-                "Setting up newrelic-log-ingestion function in region: %s"
-                % input.session.region_name
+    function = get_function(input.session, "newrelic-log-ingestion")
+    if function:
+        warning(
+            "It looks like an old log ingestion function is present in this region. "
+            "Consider manually deleting this as it is no longer used and "
+            "has been replaced by a log ingestion function specific to the stack."
+        )
+    stack_status = _check_for_ingest_stack(input.session, input.stackname)
+    if stack_status is None:
+        click.echo(
+            "Setting up CloudFormation Stack %s in region: %s"
+            % (input.stackname, input.session.region_name)
+        )
+        try:
+            _create_log_ingestion_function(
+                input,
+                nr_license_key,
             )
-            try:
-                _create_log_ingestion_function(
-                    input,
-                    nr_license_key,
-                )
-            except Exception as e:
-                failure("Failed to create newrelic-log-ingestion function: %s" % e)
-                return False
-        else:
+            return True
+        except Exception as e:
+            failure(
+                "CloudFormation Stack NewRelicLogIngestion exists (status: %s).\n"
+                "Please manually delete the stack and re-run this command."
+                % stack_status
+            )
+            return False
+    else:
+        function = get_newrelic_log_ingestion_function(input.session)
+
+        if function is None:
             failure(
                 "CloudFormation Stack NewRelicLogIngestion exists (status: %s), but "
                 "newrelic-log-ingestion Lambda function does not.\n"
@@ -594,12 +624,14 @@ def install_log_ingestion(
                 % stack_status
             )
             return False
-    else:
-        success(
-            "The newrelic-log-ingestion function already exists in region %s, "
-            "skipping" % input.session.region_name
-        )
-    return True
+        else:
+            success(
+                "The CloudFormation Stack NewRelicLogIngestion and "
+                "newrelic-log-ingestion function already exists in region %s, "
+                "skipping" % input.session.region_name
+            )
+            return True
+
 
 @catch_boto_errors
 def update_log_ingestion(input):
@@ -610,7 +642,7 @@ def update_log_ingestion(input):
     """
     assert isinstance(input, IntegrationUpdate)
 
-    stack_status = _check_for_ingest_stack(input.session)
+    stack_status = _check_for_ingest_stack(input.session, input.stackname)
     if stack_status is None:
         failure(
             "No 'NewRelicLogIngestion' stack in region '%s'. "
@@ -621,7 +653,7 @@ def update_log_ingestion(input):
         )
         return False
 
-    function = get_newrelic_log_ingestion_function(input.session)
+    function = get_newrelic_log_ingestion_function(input.session, input.stackname)
     if function is None:
         failure(
             "No newrelic-log-ingestion function in region '%s'. "

--- a/newrelic_lambda_cli/subscriptions.py
+++ b/newrelic_lambda_cli/subscriptions.py
@@ -5,6 +5,7 @@ import click
 
 from newrelic_lambda_cli.cliutils import failure, success, warning
 from newrelic_lambda_cli.functions import get_function
+from newrelic_lambda_cli.integrations import get_newrelic_log_ingestion_function
 from newrelic_lambda_cli.types import (
     LayerInstall,
     SubscriptionInstall,
@@ -83,10 +84,10 @@ def _remove_subscription_filter(session, function_name, filter_name):
 @catch_boto_errors
 def create_log_subscription(input, function_name):
     assert isinstance(input, SubscriptionInstall)
-    destination = get_function(input.session, "newrelic-log-ingestion")
+    destination = get_newrelic_log_ingestion_function(input.session)
     if destination is None:
         failure(
-            "Could not find 'newrelic-log-ingestion' function. Is the New Relic AWS "
+            "Could not find newrelic-log-ingestion function. Is the New Relic AWS "
             "integration installed?"
         )
         return False

--- a/newrelic_lambda_cli/subscriptions.py
+++ b/newrelic_lambda_cli/subscriptions.py
@@ -5,6 +5,7 @@ import click
 
 from newrelic_lambda_cli.cliutils import failure, success, warning
 from newrelic_lambda_cli.functions import get_function
+from newrelic_lambda_cli.integrations import get_unique_newrelic_log_ingestion_name
 from newrelic_lambda_cli.integrations import get_newrelic_log_ingestion_function
 from newrelic_lambda_cli.types import (
     LayerInstall,
@@ -84,7 +85,14 @@ def _remove_subscription_filter(session, function_name, filter_name):
 @catch_boto_errors
 def create_log_subscription(input, function_name):
     assert isinstance(input, SubscriptionInstall)
-    destination = get_newrelic_log_ingestion_function(input.session)
+    function = get_function(input.session, "newrelic-log-ingestion")
+    if function:
+        warning(
+            "It looks like an old log ingestion function is present in this region. "
+            "Consider manually deleting this as it is no longer used and "
+            "has been replaced by a log ingestion function specific to the stack."
+        )
+    destination = get_newrelic_log_ingestion_function(input.session, input.stackname)
     if destination is None:
         failure(
             "Could not find newrelic-log-ingestion function. Is the New Relic AWS "

--- a/newrelic_lambda_cli/templates/import-template.yaml
+++ b/newrelic_lambda_cli/templates/import-template.yaml
@@ -62,7 +62,7 @@ Resources:
         Key: 466768951184/arn:aws:serverlessrepo:us-east-1:463657938898:applications-NewRelic-log-ingestion-versions-2.2.1/2dcb4087-186a-42c8-bc1f-cf93780786c0
       Description: Sends log data from CloudWatch Logs and S3 to New Relic Infrastructure (Cloud integrations) and New Relic Logging
       Handler: function.lambda_handler
-      FunctionName: newrelic-log-ingestion
+      FunctionName: !Join ['-', ['newrelic-log-ingestion', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
       MemorySize:
         Ref: MemorySize
       Runtime: python3.9
@@ -84,7 +84,7 @@ Resources:
         Key: 466768951184/arn:aws:serverlessrepo:us-east-1:463657938898:applications-NewRelic-log-ingestion-versions-2.2.1/2dcb4087-186a-42c8-bc1f-cf93780786c0
       Description: Sends log data from CloudWatch Logs and S3 to New Relic Infrastructure (Cloud integrations) and New Relic Logging
       Handler: function.lambda_handler
-      FunctionName: newrelic-log-ingestion
+      FunctionName: !Join ['-', ['newrelic-log-ingestion', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
       MemorySize:
         Ref: MemorySize
       Runtime: python3.9

--- a/newrelic_lambda_cli/types.py
+++ b/newrelic_lambda_cli/types.py
@@ -8,6 +8,7 @@ INTEGRATION_INSTALL_KEYS = [
     "aws_permissions_check",
     "aws_role_policy",
     "enable_logs",
+    "stackname",
     "memory_size",
     "linked_account_name",
     "nr_account_id",
@@ -26,6 +27,7 @@ INTEGRATION_UNINSTALL_KEYS = [
     "aws_profile",
     "aws_region",
     "aws_permissions_check",
+    "stackname",
     "nr_account_id",
     "force",
 ]
@@ -36,6 +38,7 @@ INTEGRATION_UPDATE_KEYS = [
     "aws_region",
     "aws_permissions_check",
     "enable_logs",
+    "stackname",
     "memory_size",
     "nr_account_id",
     "nr_api_key",
@@ -80,6 +83,7 @@ SUBSCRIPTION_INSTALL_KEYS = [
     "aws_region",
     "aws_permissions_check",
     "functions",
+    "stackname",
     "excludes",
     "filter_pattern",
 ]
@@ -90,6 +94,7 @@ SUBSCRIPTION_UNINSTALL_KEYS = [
     "aws_region",
     "aws_permissions_check",
     "functions",
+    "stackname",
     "excludes",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md"), "r").read()
 
 setup(
     name="newrelic-lambda-cli",
-    version="0.8.0",
+    version="0.9.0",
     python_requires=">=3.3",
     description="A CLI to install the New Relic AWS Lambda integration and layers.",
     long_description=README,

--- a/tests/cli/test_integrations.py
+++ b/tests/cli/test_integrations.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, call, ANY
+from unittest.mock import patch, MagicMock, call, ANY
 
 from newrelic_lambda_cli.cli import cli, register_groups
 
@@ -30,7 +30,7 @@ def test_integrations_install(
     assert result.exit_code == 0, result.stderr
 
     boto3_mock.assert_has_calls(
-        [call.Session(profile_name=None, region_name="us-east-1")]
+        [call.Session(profile_name='default', region_name="us-east-1")]
     )
 
     permissions_mock.assert_has_calls(
@@ -83,7 +83,7 @@ def test_integrations_uninstall(
     assert result.exit_code == 0, result.stderr
 
     boto3_mock.assert_has_calls(
-        [call.Session(profile_name=None, region_name="us-east-1")]
+        [call.Session(profile_name='default', region_name="us-east-1")]
     )
     permissions_mock.assert_not_called()
     integrations_mock.assert_has_calls(
@@ -120,7 +120,7 @@ def test_integrations_uninstall_force(
     assert result.exit_code == 0, result.stderr
 
     boto3_mock.assert_has_calls(
-        [call.Session(profile_name=None, region_name="us-east-1")]
+        [call.Session(profile_name='default', region_name="us-east-1")]
     )
 
     permissions_mock.assert_has_calls(
@@ -163,7 +163,7 @@ def test_integrations_update(
     assert result.exit_code == 0, result.stderr
 
     boto3_mock.assert_has_calls(
-        [call.Session(profile_name=None, region_name="us-east-1")]
+        [call.Session(profile_name='default', region_name="us-east-1")]
     )
     permissions_mock.assert_has_calls(
         [call.ensure_integration_install_permissions(ANY)]

--- a/tests/cli/test_subscriptions.py
+++ b/tests/cli/test_subscriptions.py
@@ -1,8 +1,8 @@
-from moto import mock_lambda, mock_logs
+from moto import mock_lambda, mock_logs, mock_cloudformation
 
 from newrelic_lambda_cli.cli import cli, register_groups
 
-
+@mock_cloudformation
 @mock_lambda
 @mock_logs
 def test_subscriptions_install(aws_credentials, cli_runner):
@@ -30,11 +30,10 @@ def test_subscriptions_install(aws_credentials, cli_runner):
             "AWS_SESSION_TOKEN": "testing",
         },
     )
-
     assert result.exit_code == 1
     assert result.stdout == ""
     assert (
-        "Could not find 'newrelic-log-ingestion' function. "
+        "Could not find newrelic-log-ingestion function. "
         "Is the New Relic AWS integration installed?"
     ) in result.stderr
 
@@ -62,7 +61,7 @@ def test_subscriptions_install(aws_credentials, cli_runner):
     assert result2.exit_code == 1
     assert result2.stdout == ""
     assert (
-        "Could not find 'newrelic-log-ingestion' function. "
+        "Could not find newrelic-log-ingestion function. "
         "Is the New Relic AWS integration installed?"
     ) in result2.stderr
 

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -21,13 +21,24 @@ def test__get_log_group_name():
 @patch("newrelic_lambda_cli.subscriptions._create_subscription_filter", autospec=True)
 @patch("newrelic_lambda_cli.subscriptions._get_subscription_filters", autospec=True)
 @patch("newrelic_lambda_cli.subscriptions._remove_subscription_filter", autospec=True)
+@patch("newrelic_lambda_cli.integrations.get_function", autospec=True)
 @patch("newrelic_lambda_cli.subscriptions.get_function", autospec=True)
+@patch(
+    "newrelic_lambda_cli.integrations.get_unique_newrelic_log_ingestion_name",
+    autospec=True,
+)
 def test_create_log_subscription(
+    mock_get_unique_newrelic_log_ingestion_name,
+    mock_subscriptions_get_function,
     mock_get_function,
     mock_remove_subscription_filter,
     mock_get_subscription_filters,
     mock_create_subscription_filter,
 ):
+    mock_get_unique_newrelic_log_ingestion_name.return_value = "newrelic-log-ingestion"
+
+    mock_subscriptions_get_function.side_effect = None
+
     mock_get_function.side_effect = (
         None,
         {"Configuration": {"FunctionArn": "FooBarBaz"}},


### PR DESCRIPTION
Add support for newrelic-log-ingestion-xxxx name
* Install using new `newrelic-log-ingestion-<stackid>` name.
* Maintain backwards compatibility with existing installations by using old newrelic-log-ingestion name.
* This fixes https://github.com/newrelic/newrelic-lambda-cli/issues/240.