### PR TITLE
add support for nodejs20 lambda layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * nodejs12.x
 * nodejs14.x
 * nodejs16.x
+* nodejs20.x
 * provided
 * provided.al2
 * python3.7

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -38,6 +38,10 @@ RUNTIME_CONFIG = {
         "Handler": "newrelic-lambda-wrapper.handler",
         "LambdaExtension": True,
     },
+    "nodejs20.x": {
+        "Handler": "newrelic-lambda-wrapper.handler",
+        "LambdaExtension": True,
+    },
     "provided": {"LambdaExtension": True},
     "provided.al2": {"LambdaExtension": True},
     "python3.6": {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,6 +84,7 @@ def test_supports_lambda_extension():
             "nodejs14.x",
             "nodejs16.x",
             "nodejs18.x",
+            "nodejs20.x",
             "provided",
             "provided.al2",
             "python3.7",


### PR DESCRIPTION
Similarly to #241, the layer for nodejs20.x has been published, but it has not been wired into this tool.

Attempting to instrument our layers with this tool is not working, giving an error about runtime not being supported.