### PR TITLE
chore: Removed support for deprecated Node runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * java8.al2
 * java11
 * java17
-* nodejs12.x
-* nodejs14.x
 * nodejs16.x
+* nodejs18.x
 * nodejs20.x
 * provided
 * provided.al2

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -22,14 +22,6 @@ RUNTIME_CONFIG = {
         "Handler": "com.newrelic.java.HandlerWrapper::",
         "LambdaExtension": True,
     },
-    "nodejs12.x": {
-        "Handler": "newrelic-lambda-wrapper.handler",
-        "LambdaExtension": True,
-    },
-    "nodejs14.x": {
-        "Handler": "newrelic-lambda-wrapper.handler",
-        "LambdaExtension": True,
-    },
     "nodejs16.x": {
         "Handler": "newrelic-lambda-wrapper.handler",
         "LambdaExtension": True,

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -476,6 +476,6 @@ def test_uninstall(aws_credentials, mock_function_config):
 
 
 def test_layers_index():
-    layers = index("ap-southeast-1", "nodejs14.x", "x86_64")
+    layers = index("ap-southeast-1", "nodejs20.x", "x86_64")
 
     assert len(layers) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,8 +80,6 @@ def test_supports_lambda_extension():
             "java17",
             "java11",
             "java8.al2",
-            "nodejs12.x",
-            "nodejs14.x",
             "nodejs16.x",
             "nodejs18.x",
             "nodejs20.x",


### PR DESCRIPTION
Node 12 and 14 are [no longer supported by AWS](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) as runtimes for Lambda. This removes them, and adds Node 18 to the README.