### PR TITLE
Introduce support for Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * Installs and configures a New Relic AWS Lambda layer onto your AWS Lambda functions
 * Automatically selects the correct New Relic layer for your function's runtime and region
 * Wraps your AWS Lambda functions without requiring a code change
-* Supports Go, Java, .NET, Node.js and Python AWS Lambda runtimes
+* Supports Go, Java, .NET, Node.js, Python, and Ruby AWS Lambda runtimes
 * Easily uninstall the AWS Lambda layer with a single command
 
 ## Runtimes Supported
@@ -49,8 +49,9 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * python3.10
 * python3.11
 * python3.12
+* ruby3.2
 
-**Note:** Automatic handler wrapping is only supported for Node.js, Python and Java. For other runtimes,
+**Note:** Automatic handler wrapping is only supported for Node.js, Python, Java, and Ruby. For other runtimes,
 manual function wrapping is required using the runtime specific New Relic agent.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * python3.11
 * python3.12
 * ruby3.2
+* ruby3.3
 
 **Note:** Automatic handler wrapping is only supported for Node.js, Python, Java, and Ruby. For other runtimes,
 manual function wrapping is required using the runtime specific New Relic agent.

--- a/newrelic_lambda_cli/layers.py
+++ b/newrelic_lambda_cli/layers.py
@@ -153,7 +153,7 @@ def _add_new_relic(input, config, nr_license_key):
     if any("NewRelicLambdaExtension" in s for s in new_relic_layer):
         runtime_handler = None
 
-    # Only used by Python, Node.js and Java runtimes not using the
+    # Only used by Python, Node.js, Ruby, and Java runtimes not using the
     # NewRelicLambdaExtension layer
     if runtime_handler:
         update_kwargs["Handler"] = runtime_handler

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -64,6 +64,10 @@ RUNTIME_CONFIG = {
         "Handler": "newrelic_lambda_wrapper.handler",
         "LambdaExtension": True,
     },
+    "ruby3.2": {
+        "Handler": "newrelic_lambda_wrapper.handler",
+        "LambdaExtension": True,
+    },
 }
 
 

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -68,6 +68,10 @@ RUNTIME_CONFIG = {
         "Handler": "newrelic_lambda_wrapper.handler",
         "LambdaExtension": True,
     },
+    "ruby3.3": {
+        "Handler": "newrelic_lambda_wrapper.handler",
+        "LambdaExtension": True,
+    },
 }
 
 


### PR DESCRIPTION
Support the lone current AWS Lambda Ruby runtime, Ruby v3.2