### PR TITLE
al2023 support

### DIFF
--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -40,6 +40,7 @@ RUNTIME_CONFIG = {
     },
     "provided": {"LambdaExtension": True},
     "provided.al2": {"LambdaExtension": True},
+    "provided.al2023": {"LambdaExtension": True},
     "python3.7": {
         "Handler": "newrelic_lambda_wrapper.handler",
         "LambdaExtension": True,


### PR DESCRIPTION
Support for [provided.al2023](https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/) 