### PR TITLE
Support provided.al2023

### DIFF
--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -23,7 +23,7 @@ jobs:
           pipenv install --dev
           pipenv run pytest --cov-report=xml --cov=newrelic_lambda_cli tests
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c # v4.4.1
+        uses: codecov/codecov-action@v4.5.0
         with: 
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true  

--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -23,7 +23,7 @@ jobs:
           pipenv install --dev
           pipenv run pytest --cov-report=xml --cov=newrelic_lambda_cli tests
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with: 
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true  

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * nodejs20.x
 * provided
 * provided.al2
+* provided.al2023
 * python3.7
 * python3.8
 * python3.9


### PR DESCRIPTION
Update readme to add support for [provided.al2023](https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/) runtime
Update Codecov version as [v4.5.0](https://github.com/codecov/codecov-action/releases/tag/v4.5.0) solves the issue with using the existing token even if the PR is from a fork 