### PR TITLE
Log stackname for subscriptions install

### DIFF
--- a/newrelic_lambda_cli/subscriptions.py
+++ b/newrelic_lambda_cli/subscriptions.py
@@ -100,8 +100,8 @@ def create_log_subscription(input, function_name):
     destination = get_newrelic_log_ingestion_function(input.session, input.stackname)
     if destination is None:
         failure(
-            "Could not find newrelic-log-ingestion function. Is the New Relic AWS "
-            "integration installed?"
+            "Could not find newrelic-log-ingestion function in stack: %s. Is the New Relic AWS "
+            "integration installed?" % input.stackname
         )
         return False
     destination_arn = destination["Configuration"]["FunctionArn"]

--- a/tests/cli/test_subscriptions.py
+++ b/tests/cli/test_subscriptions.py
@@ -90,7 +90,7 @@ def test_subscriptions_install(aws_credentials, cli_runner):
     assert result3.exit_code == 1
     assert result3.stdout == ""
     assert (
-        "✘ Could not find newrelic-log-ingestion function in stack: MyCustomStackName. "
+        "Could not find newrelic-log-ingestion function in stack: MyCustomStackName. "
         "Is the New Relic AWS integration installed?"
     ) in result3.stderr
 

--- a/tests/cli/test_subscriptions.py
+++ b/tests/cli/test_subscriptions.py
@@ -32,7 +32,7 @@ def test_subscriptions_install(aws_credentials, cli_runner):
     assert result.exit_code == 1
     assert result.stdout == ""
     assert (
-        "Could not find newrelic-log-ingestion function. "
+        "Could not find newrelic-log-ingestion function in stack: NewRelicLogIngestion. "
         "Is the New Relic AWS integration installed?"
     ) in result.stderr
 
@@ -60,9 +60,39 @@ def test_subscriptions_install(aws_credentials, cli_runner):
     assert result2.exit_code == 1
     assert result2.stdout == ""
     assert (
-        "Could not find newrelic-log-ingestion function. "
+        "Could not find newrelic-log-ingestion function in stack: NewRelicLogIngestion. "
         "Is the New Relic AWS integration installed?"
     ) in result2.stderr
+
+    result3 = cli_runner.invoke(
+        cli,
+        [
+            "subscriptions",
+            "install",
+            "--no-aws-permissions-check",
+            "--function",
+            "foobar",
+            "--function",
+            "barbaz",
+            "--aws-region",
+            "us-east-1",
+            "--stackname",
+            "MyCustomStackName",
+        ],
+        env={
+            "AWS_ACCESS_KEY_ID": "testing",
+            "AWS_SECRET_ACCESS_KEY": "testing",
+            "AWS_SECURITY_TOKEN": "testing",
+            "AWS_SESSION_TOKEN": "testing",
+        },
+    )
+
+    assert result3.exit_code == 1
+    assert result3.stdout == ""
+    assert (
+        "✘ Could not find newrelic-log-ingestion function in stack: MyCustomStackName. "
+        "Is the New Relic AWS integration installed?"
+    ) in result3.stderr
 
 
 @mock_aws


### PR DESCRIPTION
- When using `subscriptions install` for Lambda, providing a specific CloudFormation stackname that doesn't exist or hasn't been created in the region will result in an error, with no clear indication to the user that the stackname was the issue.
- Updating the message log to print the stackname where the CLI checked for newrelic-log-ingestion function
- Previous message: `Could not find newrelic-log-ingestion function. Is the New Relic AWS integration installed?`
- New message: `Could not find newrelic-log-ingestion function in stack: NewRelicLogIngestion. Is the New Relic AWS integration installed?`