### PR TITLE
update badge from circleCI to Github Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
-# newrelic-lambda-cli [![Build Status](https://circleci.com/gh/newrelic/newrelic-lambda-cli.svg?style=svg)](https://circleci.com/gh/newrelic/newrelic-lambda-cli) [![Coverage](https://codecov.io/gh/newrelic/newrelic-lambda-cli/branch/master/graph/badge.svg?token=1Rl7h0O1JJ)](https://codecov.io/gh/newrelic/newrelic-lambda-cli)
+# newrelic-lambda-cli [![Build Status](https://github.com/newrelic/newrelic-lambda-cli/actions/workflows/build-test-release.yml/badge.svg)](https://github.com/newrelic/newrelic-lambda-cli/actions/workflows/build-test-release.yml) [![Coverage](https://codecov.io/gh/newrelic/newrelic-lambda-cli/branch/master/graph/badge.svg?token=1Rl7h0O1JJ)](https://codecov.io/gh/newrelic/newrelic-lambda-cli)
 
 A CLI to install the New Relic AWS Lambda integration and layers.
 


### PR DESCRIPTION
We have migrated from using Circle CI to Github Actions for building and Releasing Extension assets.