### PR TITLE
Add .NET 9 to supported Lambda runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * dotnetcore3.1
 * dotnet6
 * dotnet8
+* dotnet9
 * java8.al2
 * java11
 * java17

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -12,6 +12,7 @@ RUNTIME_CONFIG = {
     "dotnetcore3.1": {"LambdaExtension": True},
     "dotnet6": {"LambdaExtension": True},
     "dotnet8": {"LambdaExtension": True},
+    "dotnet9": {"LambdaExtension": True},
     "java21": {
         "Handler": "com.newrelic.java.HandlerWrapper::",
         "LambdaExtension": True,

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -239,7 +239,7 @@ def test_add_new_relic(aws_credentials, mock_function_config):
 def test_add_new_relic_dotnet(aws_credentials, mock_function_config):
     session = boto3.Session(region_name="us-east-1")
 
-    test_runtimes = ["dotnet6", "dotnet8"]
+    test_runtimes = ["dotnet6", "dotnet8", "dotnet9"]
     for test_runtime in test_runtimes:
         config = mock_function_config(test_runtime)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,7 @@ def test_supports_lambda_extension():
             "dotnetcore3.1",
             "dotnet6",
             "dotnet8",
+            "dotnet9",
             "java21",
             "java17",
             "java11",


### PR DESCRIPTION
.NET 9 went GA last week and we need to add it to the list of supported runtimes for .NET Lambdas.