### PR TITLE
Modify CLI to support AWS Lambda python3.13 & nodejs22 runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * python3.10
 * python3.11
 * python3.12
+* python3.13
 * ruby3.2
 * ruby3.3
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A CLI to install the New Relic AWS Lambda integration and layers.
 * nodejs16.x
 * nodejs18.x
 * nodejs20.x
+* nodejs22.x
 * provided
 * provided.al2
 * provided.al2023

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -40,6 +40,10 @@ RUNTIME_CONFIG = {
         "Handler": "newrelic-lambda-wrapper.handler",
         "LambdaExtension": True,
     },
+    "nodejs22.x": {
+        "Handler": "newrelic-lambda-wrapper.handler",
+        "LambdaExtension": True,
+    },
     "provided": {"LambdaExtension": True},
     "provided.al2": {"LambdaExtension": True},
     "provided.al2023": {"LambdaExtension": True},

--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -67,6 +67,10 @@ RUNTIME_CONFIG = {
         "Handler": "newrelic_lambda_wrapper.handler",
         "LambdaExtension": True,
     },
+    "python3.13": {
+        "Handler": "newrelic_lambda_wrapper.handler",
+        "LambdaExtension": True,
+    },
     "ruby3.2": {
         "Handler": "newrelic_lambda_wrapper.handler",
         "LambdaExtension": True,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md"), "r").read()
 
 setup(
     name="newrelic-lambda-cli",
-    version="0.9.4",
+    version="0.9.5",
     python_requires=">=3.3",
     description="A CLI to install the New Relic AWS Lambda integration and layers.",
     long_description=README,


### PR DESCRIPTION
- We have released [Lambda layers](https://github.com/newrelic/newrelic-lambda-layers/releases/tag/v10.3.1.1_python) for `python3.13` Lambda runtime
- We have released [Lambda layers](https://github.com/newrelic/newrelic-lambda-layers/releases/tag/v12.8.0.1_nodejs) for `nodejs22` Lambda runtime
- This PR updates CLI such that it can be used to instrument `python3.13` &  `nodejs22` Lambda runtimes with supported Lambda layers