### PR TITLE
Chore: Updating Docs for Integration-update

### DIFF
--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -44,5 +44,6 @@ jobs:
         run: |
           pip install -q -U pip
           pip install -q -U setuptools twine wheel
+          pip install -q -U packaging
           python setup.py sdist bdist_wheel
           twine check dist/*

--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ newrelic-lambda integrations update \
 
 | Option | Required? | Description |
 |--------|-----------|-------------|
-| `--nr-account-id` or `-a` | Yes | The [New Relic Account ID](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id) for the integration. Only required if changing the account to which the logs are sent. Can also use the `NEW_RELIC_ACCOUNT_ID` environment variable. |
-| `--nr-api-key` or `-k` | Yes | Your [New Relic User API Key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key). Can also use the `NEW_RELIC_API_KEY` environment variable. Only required if changing the account to which the logs are sent. |
+| `--nr-account-id` or `-a` | Yes | The [New Relic Account ID](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id) for the integration. Alternatively, you can use the `NEW_RELIC_ACCOUNT_ID` environment variable. |
+| `--nr-api-key` or `-k` | Yes | Your [New Relic User API Key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key). Alternatively, you can use the `NEW_RELIC_API_KEY` environment variable. |
 | `--disable-logs` or `-d` | No | Disables forwarding logs to New Relic Logging. Make sure you run `newrelic-lambda subscriptions install --function ...` afterwards. |
 | `--enable-logs` or `-e` | No | Enables forwarding logs to New Relic Logging. Make sure you run `newrelic-lambda subscriptions install --function ... --filter-pattern ""` afterwards. |
 | `--memory-size` or `-m` | No | Memory size (in MiB) for the New Relic log ingestion function. |


### PR DESCRIPTION
# Ticket: [NR-400566](https://new-relic.atlassian.net/browse/NR-400566)

## What is the issue?

The docs in the README for `newrelic-lambda integrations` update suggests that two arguments are optional: with the phrase "Only required if changing the account to which the logs are sent".  However, these arguments appear to be mandatory.

## How did you replicate the issue?

- Follow the guide in the [newrelic-lambda-cli repository](https://github.com/newrelic/newrelic-lambda-cli).
- Install the **`New Relic Lambda CLI`** by executing:

```sh
   pip3 install newrelic-lambda-cli
  ```
 -  Attempt to run the integrations-install command:
 
```sh
newrelic-lambda integrations install \
    --nr-account-id <account id> \
    --nr-api-key <api key>
```

## Have you done any testing and if so results of testing?
- Ran the following command:
```sh
newrelic-lambda integrations update
```

## Output
```
Usage: newrelic-lambda integrations update [OPTIONS]
Try 'newrelic-lambda integrations update --help' for help.

Error: Missing option '--nr-account-id' / '-a'.
```

## Issue regarding README Check:
Issue regarding README check arose because of a mismatch of newest `twine` with an oldish `packaging` .
So added a command to update `packaging`, by referring to the below PR.
pr: https://github.com/pypa/twine/issues/1216

[NR-400566]: https://new-relic.atlassian.net/browse/NR-400566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Issue
- Resolves #266 