### PR TITLE
feat: add Node.js ESM Handler Support via --esm Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ newrelic-lambda layers install \
 | `--nr-api-key` or `-k` | No | Your [New Relic User API Key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key). Can also use the `NEW_RELIC_API_KEY` environment variable. Only used if `--enable-extension` is set and there is no New Relic license key in AWS Secrets Manager. |
 | `--nr-region` | No | The New Relic region to use for the integration. Can use the `NEW_RELIC_REGION` environment variable. Can be either `eu` or `us`. Defaults to `us`. Only used if `--enable-extension` is set and there is no New Relic license key in AWS Secrets Manager. |
 | `--java_handler_method` or `-j` | No | For java runtimes only to specify an aws implementation method. Defaults to RequestHandler. Optional inputs are: handleRequest, handleStreamsRequest `--java_handler_method handleStreamsRequest`. |
+| `--esm` | No |  For Node.js functions using ES Modules (ESM), enable the specific ESM wrapper during installation (e.g., using the --esm flag). This sets the Lambda handler to `/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler`. |
 
 #### Uninstall Layer
 

--- a/newrelic_lambda_cli/cli/layers.py
+++ b/newrelic_lambda_cli/cli/layers.py
@@ -103,6 +103,12 @@ def register(group):
     show_default=True,
     type=click.Choice(["handleRequest", "handleStreamsRequest"]),
 )
+@click.option(
+    "--nodejs_enable_esm",
+    default=False,
+    show_default=True,
+    help="Nodejs runtimes only - Specify nodejs implementation method to /opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler",
+)
 @click.pass_context
 def install(ctx, **kwargs):
     """Install New Relic AWS Lambda Layers"""

--- a/newrelic_lambda_cli/cli/layers.py
+++ b/newrelic_lambda_cli/cli/layers.py
@@ -104,10 +104,10 @@ def register(group):
     type=click.Choice(["handleRequest", "handleStreamsRequest"]),
 )
 @click.option(
-    "--nodejs_enable_esm",
+    "--esm",
     default=False,
     show_default=True,
-    help="Nodejs runtimes only - Specify nodejs implementation method to /opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler",
+    help="Nodejs runtimes only - nodejs implementation runtime handler to /opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler",
 )
 @click.pass_context
 def install(ctx, **kwargs):

--- a/newrelic_lambda_cli/layers.py
+++ b/newrelic_lambda_cli/layers.py
@@ -100,6 +100,13 @@ def _add_new_relic(input, config, nr_license_key):
     if "java" in runtime:
         postfix = input.java_handler_method or "handleRequest"
         runtime_handler = runtime_handler + postfix
+    if "nodejs" in runtime:
+        prefix = (
+            "/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index"
+            if input.nodejs_enable_esm
+            else "newrelic_lambda_wrapper"
+        )
+        runtime_handler = prefix + ".handler"
 
     existing_newrelic_layer = [
         layer["Arn"]

--- a/newrelic_lambda_cli/layers.py
+++ b/newrelic_lambda_cli/layers.py
@@ -103,7 +103,7 @@ def _add_new_relic(input, config, nr_license_key):
     if "nodejs" in runtime:
         prefix = (
             "/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index"
-            if input.nodejs_enable_esm
+            if input.esm
             else "newrelic_lambda_wrapper"
         )
         runtime_handler = prefix + ".handler"

--- a/newrelic_lambda_cli/types.py
+++ b/newrelic_lambda_cli/types.py
@@ -107,6 +107,7 @@ LAYER_INSTALL_KEYS = [
     "enable_extension",
     "enable_extension_function_logs",
     "java_handler_method",
+    "nodejs_enable_esm",
 ]
 
 LAYER_UNINSTALL_KEYS = [

--- a/newrelic_lambda_cli/types.py
+++ b/newrelic_lambda_cli/types.py
@@ -107,7 +107,7 @@ LAYER_INSTALL_KEYS = [
     "enable_extension",
     "enable_extension_function_logs",
     "java_handler_method",
-    "nodejs_enable_esm",
+    "esm",
 ]
 
 LAYER_UNINSTALL_KEYS = [

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -299,6 +299,119 @@ def test_add_new_relic_dotnet(aws_credentials, mock_function_config):
 
 
 @mock_aws
+def test_add_new_relic_nodejs(aws_credentials, mock_function_config):
+    """
+    Tests adding New Relic layer and configuration to Node.js functions,
+    including the standard and ESM wrapper handlers.
+    """
+    session = boto3.Session(region_name="us-east-1")
+    nr_license_key = "test-license-key-nodejs"
+    nr_account_id = 12345
+
+    runtime = "nodejs20.x"
+
+    # --- Scenario 1: Standard Node.js Handler (ESM disabled) ---
+    print(f"\nTesting Node.js ({runtime}) Standard Handler...")
+    original_std_handler = "original_handler"
+    config_std = mock_function_config(runtime)
+
+    install_opts_std = layer_install(
+        session=session,
+        aws_region="us-east-1",
+        nr_account_id=nr_account_id,
+        enable_extension=True,
+        enable_extension_function_logs=True,
+    )
+
+    update_kwargs_std = _add_new_relic(
+        install_opts_std,
+        config_std,
+        nr_license_key=nr_license_key,
+    )
+
+    assert update_kwargs_std is not False, "Expected update_kwargs, not False"
+    assert (
+        update_kwargs_std["FunctionName"] == config_std["Configuration"]["FunctionArn"]
+    )
+    assert update_kwargs_std["Handler"] == "newrelic_lambda_wrapper.handler"
+    assert (
+        update_kwargs_std["Environment"]["Variables"]["NEW_RELIC_LAMBDA_HANDLER"]
+        == original_std_handler
+    )
+    assert update_kwargs_std["Environment"]["Variables"]["NEW_RELIC_ACCOUNT_ID"] == str(
+        nr_account_id
+    )
+    assert (
+        update_kwargs_std["Environment"]["Variables"]["NEW_RELIC_LICENSE_KEY"]
+        == nr_license_key
+    )
+    assert (
+        update_kwargs_std["Environment"]["Variables"][
+            "NEW_RELIC_LAMBDA_EXTENSION_ENABLED"
+        ]
+        == "true"
+    )
+    assert (
+        update_kwargs_std["Environment"]["Variables"][
+            "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS"
+        ]
+        == "true"
+    )
+
+    # --- Scenario 2: ESM Node.js Handler (ESM enabled) ---
+    print(f"\nTesting Node.js ({runtime}) ESM Handler...")
+    original_esm_handler = "original_handler"
+    config_esm = mock_function_config(runtime)
+
+    install_opts_esm = layer_install(
+        session=session,
+        aws_region="us-east-1",
+        nr_account_id=nr_account_id,
+        enable_extension=True,
+        enable_extension_function_logs=True,
+        esm=True,
+    )
+
+    update_kwargs_esm = _add_new_relic(
+        install_opts_esm,
+        config_esm,
+        nr_license_key=nr_license_key,
+    )
+
+    assert update_kwargs_esm is not False, "Expected update_kwargs, not False"
+    assert (
+        update_kwargs_esm["FunctionName"] == config_esm["Configuration"]["FunctionArn"]
+    )
+    assert (
+        update_kwargs_esm["Handler"]
+        == "/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler"
+    )
+    assert (
+        update_kwargs_esm["Environment"]["Variables"]["NEW_RELIC_LAMBDA_HANDLER"]
+        == original_esm_handler
+    )
+    assert update_kwargs_esm["Environment"]["Variables"]["NEW_RELIC_ACCOUNT_ID"] == str(
+        nr_account_id
+    )
+    assert (
+        update_kwargs_esm["Environment"]["Variables"]["NEW_RELIC_LICENSE_KEY"]
+        == nr_license_key
+    )
+    assert (
+        update_kwargs_esm["Environment"]["Variables"][
+            "NEW_RELIC_LAMBDA_EXTENSION_ENABLED"
+        ]
+        == "true"
+    )
+    assert (
+        update_kwargs_esm["Environment"]["Variables"][
+            "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS"
+        ]
+        == "true"
+    )
+
+
+@mock_aws
 def test_remove_new_relic(aws_credentials, mock_function_config):
     session = boto3.Session(region_name="us-east-1")
 


### PR DESCRIPTION
**Add Node.js ESM Handler Support via `--esm` Flag**

This change allows users to specify that their Node.js function uses ES Modules, ensuring the correct New Relic wrapper handler is configured.

**Key Changes:**

* **New `--esm` Flag:** Introduced a boolean flag `--esm` for the `layers install` command. Its presence indicates an ESM project.
* **Conditional Handler Logic:**
    * The ESM handler (`/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler`) is now used for Node.js runtimes when the `--esm` flag is included in the command.
    * The default CommonJS handler (`newrelic-lambda-wrapper.handler`) is used otherwise. 
* **Testing:** Added test cases covering Node.js installations both with and without the `--esm` flag to validate handler logic.
* **Documentation:** Updated the `README.md` to explain how and when to use the `--esm` flag.

### Usage:
```
newrelic-lambda layers install \
  --function `lambda-function-name`  \
  --nr-account-id  `NR-accountid`  \
  --nr-api-key `NR-user-key`  \
  --esm true
```

### Issues
- Closes #313 