### PR TITLE
fix: fixed the env handler is updating during upgrade nodejs

### DIFF
--- a/newrelic_lambda_cli/layers.py
+++ b/newrelic_lambda_cli/layers.py
@@ -172,7 +172,18 @@ def _add_new_relic(input, config, nr_license_key):
 
     # Update the NEW_RELIC_LAMBDA_HANDLER envvars only when it's a new install.
     if runtime_handler and handler != runtime_handler:
-        update_kwargs["Environment"]["Variables"]["NEW_RELIC_LAMBDA_HANDLER"] = handler
+        if "nodejs" in runtime:
+            if handler not in [
+                "newrelic-lambda-wrapper.handler",
+                "/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler",
+            ]:
+                update_kwargs["Environment"]["Variables"][
+                    "NEW_RELIC_LAMBDA_HANDLER"
+                ] = handler
+        else:
+            update_kwargs["Environment"]["Variables"][
+                "NEW_RELIC_LAMBDA_HANDLER"
+            ] = handler
 
     if input.enable_extension and not utils.supports_lambda_extension(runtime):
         warning(


### PR DESCRIPTION
### Description: 
- This PR Resolves the issue that env handler is getting upgraded during `upgrade` command

### Tests Done: 
**During Initial Installation (without --esm):**
- The Lambda handler is updated to `newrelic-lambda-wrapper.handler`.
- The handler environment variable is updated.

**During Initial Installation (with --esm):**
- The Lambda handler is updated to `/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler`.
- The handler environment variable is updated.

**During Upgrade (from a non-ESM setup to ESM) :**
- The Lambda handler is updated to `/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler`.
- The handler environment variable is not updated.

**During Upgrade (from an ESM setup to non-ESM):**
- The Lambda handler is updated to `newrelic-lambda-wrapper.handler`.
- The handler environment variable is not updated.

**During Initial Installation for ruby and python function**
- The Lambda handler is updated to `newrelic_lambda_wrapper.handler`.
-  The handler environment variable is updated.

**During Upgrade for ruby and python function**
- The Lambda handler is updated to `newrelic_lambda_wrapper.handler`.
-  The handler environment variable is not updated.