### PR TITLE
feat: updated logic for parse_arn

### DIFF
--- a/newrelic_lambda_cli/utils.py
+++ b/newrelic_lambda_cli/utils.py
@@ -187,7 +187,6 @@ def parse_arn(arn):
         result["resource"] = elements[5]
         result["resourcetype"] = None
     else:
-        print(elements[5])
         splitted_arn = elements[5].split("/")
         result["resourcetype"] = splitted_arn[0]
         result["resource"] = "/".join(splitted_arn[1:])


### PR DESCRIPTION
# Ticket: [NR-401055](https://new-relic.atlassian.net/browse/NR-401055)

## Details:
- I modified the logic of the `parse_arn` function in `utils.py` to correctly categorize ARNs, such as `arn:aws:iam::xxxxxxxx:role/acct-managed/NewRelicInfrastructure-Integrations`, by organizing them into resource type and resource. Additionally, I ensured there are no errors related to external IDs.

[NR-401055]: https://new-relic.atlassian.net/browse/NR-401055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



## Related issues : 
#201 


