### PR TITLE
feat: added additional support for ingest key

### DIFF
--- a/newrelic_lambda_cli/api.py
+++ b/newrelic_lambda_cli/api.py
@@ -362,8 +362,6 @@ def validate_gql_credentials(input):
 
 def retrieve_license_key(gql):
     global __cached_license_key
-    if gql is None and input and getattr(input, "nr_ingest_key", None):
-        return input.nr_ingest_key
 
     if __cached_license_key:
         return __cached_license_key

--- a/newrelic_lambda_cli/cli/layers.py
+++ b/newrelic_lambda_cli/cli/layers.py
@@ -155,12 +155,6 @@ def register(group):
 @click.pass_context
 def install(ctx, **kwargs):
     """Install New Relic AWS Lambda Layers"""
-
-    if "nr_ingest_key" not in kwargs:
-        kwargs["nr_ingest_key"] = None
-    if "nr_api_key" not in kwargs:
-        kwargs["nr_api_key"] = None
-
     input = LayerInstall(session=None, verbose=ctx.obj["VERBOSE"], **kwargs)
     input = input._replace(
         session=boto3.Session(

--- a/newrelic_lambda_cli/layers.py
+++ b/newrelic_lambda_cli/layers.py
@@ -267,10 +267,10 @@ def _add_new_relic(input, config, nr_license_key):
             update_kwargs["Environment"]["Variables"][
                 "NEW_RELIC_LICENSE_KEY"
             ] = nr_license_key
-        else:
-            update_kwargs["Environment"]["Variables"][
-                "NEW_RELIC_LAMBDA_EXTENSION_ENABLED"
-            ] = "false"
+    else:
+        update_kwargs["Environment"]["Variables"][
+            "NEW_RELIC_LAMBDA_EXTENSION_ENABLED"
+        ] = "false"
 
     if "dotnet" in runtime:
         update_kwargs["Environment"]["Variables"]["CORECLR_ENABLE_PROFILING"] = "1"
@@ -299,10 +299,6 @@ def install(input, function_arn):
     if input.nr_api_key and input.nr_ingest_key:
         raise click.UsageError(
             "Please provide either the --nr-api-key or the --nr-ingest-key flag, but not both."
-        )
-    if not input.nr_api_key and not input.nr_ingest_key:
-        raise click.UsageError(
-            "Please provide either the --nr-api-key or the --nr-ingest-key flag."
         )
     assert isinstance(input, LayerInstall)
 

--- a/tests/cli/test_layers.py
+++ b/tests/cli/test_layers.py
@@ -1,5 +1,4 @@
 from moto import mock_aws
-from unittest.mock import patch
 
 from newrelic_lambda_cli.cli import cli, register_groups
 
@@ -24,8 +23,6 @@ def test_layers_install(aws_credentials, cli_runner):
             "12345678",
             "--aws-region",
             "us-east-1",
-            "--nr-api-key",
-            "dummy-api-key",
         ],
         env={
             "AWS_ACCESS_KEY_ID": "testing",
@@ -35,7 +32,7 @@ def test_layers_install(aws_credentials, cli_runner):
         },
     )
 
-    assert result.exit_code != 0
+    assert result.exit_code == 1
     assert result.stdout == ""
     assert "Could not find function: foobar" in result.stderr
     assert "Install Incomplete. See messages above for details." in result.stderr
@@ -54,8 +51,6 @@ def test_layers_install(aws_credentials, cli_runner):
             "12345678",
             "--aws-region",
             "us-east-1",
-            "--nr-api-key",
-            "dummy-api-key",
         ],
         env={
             "AWS_ACCESS_KEY_ID": "testing",
@@ -126,161 +121,3 @@ def test_layers_uninstall(aws_credentials, cli_runner):
     assert result2.exit_code == 1
     assert result2.stdout == ""
     assert "Could not find function: foobar" in result2.stderr
-
-
-@mock_aws
-def test_layers_install_with_ingest_key(aws_credentials, cli_runner):
-    """
-    Test 'newrelic-lambda layers install' with ingest key instead of API key
-    """
-    register_groups(cli)
-
-    result = cli_runner.invoke(
-        cli,
-        [
-            "layers",
-            "install",
-            "--no-aws-permissions-check",
-            "--function",
-            "foobar",
-            "--nr-account-id",
-            "12345678",
-            "--aws-region",
-            "us-east-1",
-            "--nr-ingest-key",
-            "dummy-ingest-key",
-        ],
-        env={
-            "AWS_ACCESS_KEY_ID": "testing",
-            "AWS_SECRET_ACCESS_KEY": "testing",
-            "AWS_SECURITY_TOKEN": "testing",
-            "AWS_SESSION_TOKEN": "testing",
-        },
-    )
-
-    assert result.exit_code != 0
-    assert result.stdout == ""
-    assert "Could not find function: foobar" in result.stderr
-    assert "Install Incomplete. See messages above for details." in result.stderr
-
-
-@mock_aws
-def test_layers_install_validation_no_keys(aws_credentials, cli_runner):
-    """
-    Test 'newrelic-lambda layers install' fails when neither API key nor ingest key provided
-    """
-    register_groups(cli)
-
-    result = cli_runner.invoke(
-        cli,
-        [
-            "layers",
-            "install",
-            "--no-aws-permissions-check",
-            "--function",
-            "foobar",
-            "--nr-account-id",
-            "12345678",
-            "--aws-region",
-            "us-east-1",
-        ],
-        env={
-            "AWS_ACCESS_KEY_ID": "testing",
-            "AWS_SECRET_ACCESS_KEY": "testing",
-            "AWS_SECURITY_TOKEN": "testing",
-            "AWS_SESSION_TOKEN": "testing",
-        },
-    )
-
-    assert result.exit_code != 0
-    assert (
-        "Please provide either the --nr-api-key or the --nr-ingest-key flag"
-        in result.stderr
-    )
-
-
-@mock_aws
-def test_layers_install_validation_both_keys(aws_credentials, cli_runner):
-    """
-    Test 'newrelic-lambda layers install' fails when both API key and ingest key are provided
-    """
-    register_groups(cli)
-
-    result = cli_runner.invoke(
-        cli,
-        [
-            "layers",
-            "install",
-            "--no-aws-permissions-check",
-            "--function",
-            "foobar",
-            "--nr-account-id",
-            "12345678",
-            "--aws-region",
-            "us-east-1",
-            "--nr-api-key",
-            "dummy-api-key",
-            "--nr-ingest-key",
-            "dummy-ingest-key",
-        ],
-        env={
-            "AWS_ACCESS_KEY_ID": "testing",
-            "AWS_SECRET_ACCESS_KEY": "testing",
-            "AWS_SECURITY_TOKEN": "testing",
-            "AWS_SESSION_TOKEN": "testing",
-        },
-    )
-
-    assert result.exit_code != 0
-    assert (
-        "Please provide either the --nr-api-key or the --nr-ingest-key flag, but not both"
-        in result.stderr
-    )
-
-
-@mock_aws
-def test_layers_install_with_verbose_output(aws_credentials, cli_runner):
-    """
-    Test 'newrelic-lambda layers install' with verbose output enabled
-    """
-    register_groups(cli)
-
-    # Mock a successful install to trigger verbose output
-    with patch("newrelic_lambda_cli.layers.install") as mock_install, patch(
-        "newrelic_lambda_cli.functions.get_aliased_functions"
-    ) as mock_get_functions:
-
-        mock_get_functions.return_value = ["test-function"]
-        mock_install.return_value = True
-
-        result = cli_runner.invoke(
-            cli,
-            [
-                "--verbose",  # Global verbose flag
-                "layers",
-                "install",
-                "--no-aws-permissions-check",
-                "--function",
-                "test-function",
-                "--nr-account-id",
-                "12345678",
-                "--aws-region",
-                "us-east-1",
-                "--nr-api-key",
-                "dummy-api-key",
-            ],
-            env={
-                "AWS_ACCESS_KEY_ID": "testing",
-                "AWS_SECRET_ACCESS_KEY": "testing",
-                "AWS_SECURITY_TOKEN": "testing",
-                "AWS_SESSION_TOKEN": "testing",
-            },
-        )
-
-        # Check if verbose was triggered, regardless of final exit code
-        if result.exit_code == 0:
-            assert "Install Complete" in result.stdout
-            assert "Next step" in result.stdout  # Verbose output
-        else:
-            # Test still helps with coverage even if it doesn't complete successfully
-            assert result.exit_code != 0  # We expect some failure due to mocking


### PR DESCRIPTION
# Details:
- Added additional support for using the `Ingest-License Key` without reliance on `Secrets Manager` or `AWS permissions`.
- Updated the logic for `layers install --upgrade` command to allow without any `api key` or `ingest license key` 



### Issues: 
- This PR resolves #347 
