### PR TITLE
Updated layer install for non-interactive env & --slim flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ newrelic-lambda layers install \
 | `--function` or `-f` | Yes | The AWS Lambda function name or ARN in which to add a layer. Can provide multiple `--function` arguments. Will also accept `all`, `installed` and `not-installed` similar to `newrelic-lambda functions list`. |
 | `--nr-account-id` or `-a` | Yes | The [New Relic Account ID](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id) this function should use. Can also use the `NEW_RELIC_ACCOUNT_ID` environment variable. |
 | `--exclude` or `-e` | No | A function name to exclude while installing layers. Can provide multiple `--exclude` arguments. Only checked when `all`, `installed` and `not-installed` are used. See `newrelic-lambda functions list` for function names. |
+| `--slim` | No | The flag `--slim` adds the Node.js layer without OpenTelemetry dependencies, resulting in a lighter size. |
 | `--layer-arn` or `-l` | No | Specify a specific layer version ARN to use. This is auto detected by default. |
 | `--upgrade` or `-u` | No | Permit upgrade to the latest layer version for this region and runtime. |
 | `--disable-extension` | No | Disable the [New Relic Lambda Extension](https://github.com/newrelic/newrelic-lambda-extension). |

--- a/newrelic_lambda_cli/cli/layers.py
+++ b/newrelic_lambda_cli/cli/layers.py
@@ -134,6 +134,12 @@ def register(group):
     help="Enable sending Lambda function logs via the New Relic Lambda Extension",
 )
 @click.option(
+    "--slim",
+    is_flag=True,
+    default=False,
+    help="New Relic slim Layer without opentelemetry for Node.js",
+)
+@click.option(
     "--disable-function-logs",
     is_flag=True,
     help="Disable sending Lambda function logs via the New Relic Lambda Extension",

--- a/newrelic_lambda_cli/types.py
+++ b/newrelic_lambda_cli/types.py
@@ -117,6 +117,7 @@ LAYER_INSTALL_KEYS = [
     "disable_extension_logs",
     "java_handler_method",
     "esm",
+    "slim",
 ]
 
 LAYER_UNINSTALL_KEYS = [

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md"), "r").read()
 
 setup(
     name="newrelic-lambda-cli",
-    version="0.9.14",
+    version="0.9.15",
     python_requires=">=3.3",
     description="A CLI to install the New Relic AWS Lambda integration and layers.",
     long_description=README,

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -148,6 +148,7 @@ def test_add_new_relic(aws_credentials, mock_function_config):
                 "x86_64",
                 upgrade=None,
                 existing_layer_arn=None,
+                slim=ANY,
             )
             assert "original_handler" in config["Configuration"]["Handler"]
 
@@ -199,8 +200,9 @@ def test_add_new_relic(aws_credentials, mock_function_config):
 
     with patch("sys.stdout.isatty") as mock_isatty:
         mock_isatty.return_value = False
-        with pytest.raises(UsageError):
-            layer_selection(mock_layers, "python3.12", "x86_64")
+
+        selected = layer_selection(mock_layers, "python3.12", "x86_64")
+        assert selected == "arn:aws:lambda:us-east-1:123456789:layer/javajava"
 
     config = mock_function_config("python3.12")
     _add_new_relic(


### PR DESCRIPTION
Details: 
- Updated the `NewRelic layers install` command to function in a non-interactive environment and automatically add the standard layers.