### PR TITLE
feat: Added support for NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ newrelic-lambda layers install \
 | `--disable-extension-function-logs` or `--disable-function-logs` | No | Disable sending Lambda function logs via the [New Relic Lambda Extension](https://github.com/newrelic/newrelic-lambda-extension).|
 | `--send-extension-logs` | No | Enable forwarding logs via the [New Relic Lambda Extension](https://github.com/newrelic/newrelic-lambda-extension). Disabled by default. |
 | `--disable-extension-logs` | No | Disable forwarding logs via the [New Relic Lambda Extension](https://github.com/newrelic/newrelic-lambda-extension).|
+| `--send-platform-logs` | No | Enable sending Lambda platform logs via the [New Relic Lambda Extension](https://github.com/newrelic/newrelic-lambda-extension). Sets `NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS` to `true`. Disabled by default. |
+| `--disable-platform-logs` | No | Disable sending Lambda platform logs via the [New Relic Lambda Extension](https://github.com/newrelic/newrelic-lambda-extension). Sets `NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS` to `false`. |
 | `--aws-profile` or `-p` | No | The AWS profile to use for this command. Can also use `AWS_PROFILE`. Will also check `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables if not using AWS CLI. |
 | `--aws-region` or `-r` | No | The AWS region this function is located. Can use `AWS_DEFAULT_REGION` environment variable. Defaults to AWS session region. |
 | `--nr-api-key` or `-k` | No | Your [New Relic User API Key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key). Can also use the `NEW_RELIC_API_KEY` environment variable. Only used if `--enable-extension` is set and there is no New Relic license key in AWS Secrets Manager. |

--- a/newrelic_lambda_cli/cli/layers.py
+++ b/newrelic_lambda_cli/cli/layers.py
@@ -145,6 +145,16 @@ def register(group):
     help="Disable sending Lambda function logs via the New Relic Lambda Extension",
 )
 @click.option(
+    "--send-platform-logs",
+    is_flag=True,
+    help="Enable sending Lambda platform logs via the New Relic Lambda Extension",
+)
+@click.option(
+    "--disable-platform-logs",
+    is_flag=True,
+    help="Disable sending Lambda platform logs via the New Relic Lambda Extension",
+)
+@click.option(
     "--java_handler_method",
     "-j",
     default="handleRequest",

--- a/newrelic_lambda_cli/layers.py
+++ b/newrelic_lambda_cli/layers.py
@@ -142,16 +142,18 @@ def _add_new_relic(input, config, nr_license_key):
         if layer["Arn"].startswith(utils.get_arn_prefix(aws_region))
     ]
 
-    has_log_flags = any([
-        input.send_function_logs,
-        input.disable_function_logs,
-        input.enable_extension_function_logs,
-        input.disable_extension_function_logs,
-        input.send_extension_logs,
-        input.disable_extension_logs,
-        input.send_platform_logs,
-        input.disable_platform_logs,
-    ])
+    has_log_flags = any(
+        [
+            input.send_function_logs,
+            input.disable_function_logs,
+            input.enable_extension_function_logs,
+            input.disable_extension_function_logs,
+            input.send_extension_logs,
+            input.disable_extension_logs,
+            input.send_platform_logs,
+            input.disable_platform_logs,
+        ]
+    )
 
     if not input.upgrade and existing_newrelic_layer and not has_log_flags:
         success(

--- a/newrelic_lambda_cli/layers.py
+++ b/newrelic_lambda_cli/layers.py
@@ -20,6 +20,7 @@ NEW_RELIC_ENV_VARS = (
     "NEW_RELIC_ACCOUNT_ID",
     "NEW_RELIC_EXTENSION_SEND_EXTENSION_LOGS",
     "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS",
+    "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS",
     "NEW_RELIC_LAMBDA_EXTENSION_ENABLED",
     "NEW_RELIC_LAMBDA_HANDLER",
     "NEW_RELIC_LICENSE_KEY",
@@ -141,7 +142,18 @@ def _add_new_relic(input, config, nr_license_key):
         if layer["Arn"].startswith(utils.get_arn_prefix(aws_region))
     ]
 
-    if not input.upgrade and existing_newrelic_layer:
+    has_log_flags = any([
+        input.send_function_logs,
+        input.disable_function_logs,
+        input.enable_extension_function_logs,
+        input.disable_extension_function_logs,
+        input.send_extension_logs,
+        input.disable_extension_logs,
+        input.send_platform_logs,
+        input.disable_platform_logs,
+    ])
+
+    if not input.upgrade and existing_newrelic_layer and not has_log_flags:
         success(
             "Already installed on function '%s'. Pass --upgrade (or -u) to allow "
             "upgrade or reinstall to latest layer version."
@@ -236,11 +248,7 @@ def _add_new_relic(input, config, nr_license_key):
             "NEW_RELIC_LAMBDA_EXTENSION_ENABLED"
         ] = "true"
 
-        if not input.upgrade:
-            update_kwargs["Environment"]["Variables"][
-                "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS"
-            ] = "false"
-        elif input.enable_extension_function_logs or input.send_function_logs:
+        if input.enable_extension_function_logs or input.send_function_logs:
             update_kwargs["Environment"]["Variables"][
                 "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS"
             ] = "true"
@@ -254,12 +262,12 @@ def _add_new_relic(input, config, nr_license_key):
             success(
                 "Successfully disabled NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS tag to the function"
             )
-
-        if not input.upgrade:
+        elif not input.upgrade:
             update_kwargs["Environment"]["Variables"][
-                "NEW_RELIC_EXTENSION_SEND_EXTENSION_LOGS"
+                "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS"
             ] = "false"
-        elif input.send_extension_logs:
+
+        if input.send_extension_logs:
             update_kwargs["Environment"]["Variables"][
                 "NEW_RELIC_EXTENSION_SEND_EXTENSION_LOGS"
             ] = "true"
@@ -273,6 +281,29 @@ def _add_new_relic(input, config, nr_license_key):
             success(
                 "Successfully disabled NEW_RELIC_EXTENSION_SEND_EXTENSION_LOGS tag to the function"
             )
+        elif not input.upgrade:
+            update_kwargs["Environment"]["Variables"][
+                "NEW_RELIC_EXTENSION_SEND_EXTENSION_LOGS"
+            ] = "false"
+
+        if input.send_platform_logs:
+            update_kwargs["Environment"]["Variables"][
+                "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS"
+            ] = "true"
+            success(
+                "Successfully enabled NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS tag to the function"
+            )
+        elif input.disable_platform_logs:
+            update_kwargs["Environment"]["Variables"][
+                "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS"
+            ] = "false"
+            success(
+                "Successfully disabled NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS tag to the function"
+            )
+        elif not input.upgrade:
+            update_kwargs["Environment"]["Variables"][
+                "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS"
+            ] = "false"
 
         if input.nr_tags:
             update_kwargs["Environment"]["Variables"]["NR_TAGS"] = input.nr_tags

--- a/newrelic_lambda_cli/types.py
+++ b/newrelic_lambda_cli/types.py
@@ -115,6 +115,8 @@ LAYER_INSTALL_KEYS = [
     "disable_function_logs",
     "send_extension_logs",
     "disable_extension_logs",
+    "send_platform_logs",
+    "disable_platform_logs",
     "java_handler_method",
     "esm",
     "slim",

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -55,7 +55,7 @@ def test_add_new_relic(aws_credentials, mock_function_config):
         update_kwargs["Environment"]["Variables"][
             "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS"
         ]
-        == "false"
+        == "true"
     )
 
     config = mock_function_config("not.a.runtime")
@@ -76,20 +76,19 @@ def test_add_new_relic(aws_credentials, mock_function_config):
 
     config = mock_function_config("python3.12")
     config["Configuration"]["Layers"] = [{"Arn": get_arn_prefix("us-east-1")}]
-    assert (
-        _add_new_relic(
-            layer_install(
-                session=session,
-                aws_region="us-east-1",
-                nr_account_id=12345,
-                enable_extension=True,
-                enable_extension_function_logs=True,
-            ),
-            config,
-            nr_license_key=None,
-        )
-        is True
+    result = _add_new_relic(
+        layer_install(
+            session=session,
+            aws_region="us-east-1",
+            nr_account_id=12345,
+            enable_extension=True,
+            enable_extension_function_logs=True,
+        ),
+        config,
+        nr_license_key=None,
     )
+    # With log flags set, the function proceeds to update even if layer exists
+    assert result is not False
 
     with patch("newrelic_lambda_cli.layers.index") as mock_index:
         mock_index.return_value = []
@@ -390,7 +389,7 @@ def test_add_new_relic_dotnet(aws_credentials, mock_function_config):
             update_kwargs["Environment"]["Variables"][
                 "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS"
             ]
-            == "false"
+            == "true"
         )
 
         # .NET specific environment variables
@@ -472,7 +471,7 @@ def test_add_new_relic_nodejs(aws_credentials, mock_function_config):
         update_kwargs_std["Environment"]["Variables"][
             "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS"
         ]
-        == "false"
+        == "true"
     )
 
     # --- Scenario 2: ESM Node.js Handler (ESM enabled) ---
@@ -529,7 +528,7 @@ def test_add_new_relic_nodejs(aws_credentials, mock_function_config):
         update_kwargs_esm["Environment"]["Variables"][
             "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS"
         ]
-        == "false"
+        == "true"
     )
 
 
@@ -840,7 +839,7 @@ def test_extension_logs_flags(aws_credentials, mock_function_config):
         == "false"
     )
 
-    # Test 2: Fresh install with --send-extension-logs
+    # Test 2: Fresh install with --send-extension-logs - should be true
     config = mock_function_config("python3.12")
     update_kwargs = _add_new_relic(
         layer_install(
@@ -858,7 +857,7 @@ def test_extension_logs_flags(aws_credentials, mock_function_config):
         update_kwargs["Environment"]["Variables"][
             "NEW_RELIC_EXTENSION_SEND_EXTENSION_LOGS"
         ]
-        == "false"
+        == "true"
     )
 
     # Test 3: Upgrade with --send-extension-logs - should set to true
@@ -965,7 +964,7 @@ def test_function_logs_flags(aws_credentials, mock_function_config):
         == "false"
     )
 
-    # Test 2: Fresh install with --send-function-logs - should still be false
+    # Test 2: Fresh install with --send-function-logs - should be true
     config = mock_function_config("python3.12")
     update_kwargs = _add_new_relic(
         layer_install(
@@ -983,7 +982,7 @@ def test_function_logs_flags(aws_credentials, mock_function_config):
         update_kwargs["Environment"]["Variables"][
             "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS"
         ]
-        == "false"
+        == "true"
     )
 
     # Test 3: Upgrade with --send-function-logs - should set to true
@@ -1059,6 +1058,131 @@ def test_function_logs_flags(aws_credentials, mock_function_config):
     assert (
         update_kwargs["Environment"]["Variables"][
             "NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS"
+        ]
+        == "true"
+    )
+
+
+@mock_aws
+def test_platform_logs_flags(aws_credentials, mock_function_config):
+    """Test that --send-platform-logs and --disable-platform-logs flags work correctly"""
+    session = boto3.Session(region_name="us-east-1")
+    nr_account_id = 12345
+
+    # Test 1: Fresh install with default settings - logs should be disabled by default
+    config = mock_function_config("python3.12")
+    update_kwargs = _add_new_relic(
+        layer_install(
+            session=session,
+            aws_region="us-east-1",
+            nr_account_id=nr_account_id,
+            enable_extension=True,
+        ),
+        config,
+        nr_license_key=None,
+    )
+
+    assert (
+        update_kwargs["Environment"]["Variables"][
+            "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS"
+        ]
+        == "false"
+    )
+
+    # Test 2: Fresh install with --send-platform-logs - should be true
+    config = mock_function_config("python3.12")
+    update_kwargs = _add_new_relic(
+        layer_install(
+            session=session,
+            aws_region="us-east-1",
+            nr_account_id=nr_account_id,
+            enable_extension=True,
+            send_platform_logs=True,
+        ),
+        config,
+        nr_license_key=None,
+    )
+
+    assert (
+        update_kwargs["Environment"]["Variables"][
+            "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS"
+        ]
+        == "true"
+    )
+
+    # Test 3: Upgrade with --send-platform-logs - should set to true
+    config = mock_function_config("python3.12")
+    config["Configuration"]["Environment"]["Variables"][
+        "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS"
+    ] = "false"
+
+    update_kwargs = _add_new_relic(
+        layer_install(
+            session=session,
+            aws_region="us-east-1",
+            nr_account_id=nr_account_id,
+            enable_extension=True,
+            send_platform_logs=True,
+            upgrade=True,
+        ),
+        config,
+        nr_license_key=None,
+    )
+
+    assert (
+        update_kwargs["Environment"]["Variables"][
+            "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS"
+        ]
+        == "true"
+    )
+
+    # Test 4: Upgrade with --disable-platform-logs - should set to false
+    config = mock_function_config("python3.12")
+    config["Configuration"]["Environment"]["Variables"][
+        "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS"
+    ] = "true"
+
+    update_kwargs = _add_new_relic(
+        layer_install(
+            session=session,
+            aws_region="us-east-1",
+            nr_account_id=nr_account_id,
+            enable_extension=True,
+            disable_platform_logs=True,
+            upgrade=True,
+        ),
+        config,
+        nr_license_key=None,
+    )
+
+    assert (
+        update_kwargs["Environment"]["Variables"][
+            "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS"
+        ]
+        == "false"
+    )
+
+    # Test 5: Upgrade without flags - should preserve existing value
+    config = mock_function_config("python3.12")
+    config["Configuration"]["Environment"]["Variables"][
+        "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS"
+    ] = "true"
+
+    update_kwargs = _add_new_relic(
+        layer_install(
+            session=session,
+            aws_region="us-east-1",
+            nr_account_id=nr_account_id,
+            enable_extension=True,
+            upgrade=True,
+        ),
+        config,
+        nr_license_key=None,
+    )
+
+    assert (
+        update_kwargs["Environment"]["Variables"][
+            "NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS"
         ]
         == "true"
     )


### PR DESCRIPTION
Details:
- Use **`--send-platform-logs` and `--disable-platform-logs`** flags to layers install to control `NEW_RELIC_EXTENSION_SEND_PLATFORM_LOGS` on fresh installs, upgrades, and already-instrumented functions.

